### PR TITLE
Fix names and titles on team & contact pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -36,9 +36,9 @@
       <ul class="contacts-list">
         <li>Robert Bruckner, CEO – <a href="mailto:bob@thalos.at">bob@thalos.at</a></li>
         <li>Prof. Dr. Ronald Hochreiter, Head of AI – <a href="mailto:ron@thalos.at">ron@thalos.at</a></li>
-        <li>Dr. Michael Handschur, CSO – <a href="mailto:mike@thalos.at">mike@thalos.at</a></li>
-        <li>Dr. Mikhail Ivanov, CTO – <a href="mailto:mikhail@thalos.at">mikhail@thalos.at</a></li>
-        <li>Andreas Pürzel, Strength Mentor (DASGYM) – <a href="mailto:andi@thalos.at">andi@thalos.at</a></li>
+        <li>Dr. Michael "Mike" Handschur, CSO – <a href="mailto:mike@thalos.at">mike@thalos.at</a></li>
+        <li>Dr. Mikhail "Misha" Ivanov, CTO – <a href="mailto:misha@thalos.at">misha@thalos.at</a></li>
+        <li>Andreas "Andi" Pürzel, Athletic Lead – <a href="mailto:andi@thalos.at">andi@thalos.at</a></li>
       </ul>
     </section>
   </main>

--- a/team.html
+++ b/team.html
@@ -45,20 +45,20 @@
         </div>
         <div class="team-member">
           <img src="images/michael.jpg" alt="Dr. Michael Handschur portrait" />
-          <h3>Dr. Michael Handschur</h3>
+          <h3>Dr. Michael "Mike" Handschur</h3>
           <p>Chief Science Officer</p>
           <p><a href="mailto:mike@thalos.at">mike@thalos.at</a></p>
         </div>
         <div class="team-member">
           <img src="images/mikhail.jpg" alt="Dr. Mikhail Ivanov portrait" />
-          <h3>Dr. Mikhail Ivanov</h3>
+          <h3>Dr. Mikhail "Misha" Ivanov</h3>
           <p>Chief Technology Officer</p>
-          <p><a href="mailto:mikhail@thalos.at">mikhail@thalos.at</a></p>
+          <p><a href="mailto:misha@thalos.at">misha@thalos.at</a></p>
         </div>
         <div class="team-member">
           <img src="images/andreas.jpg" alt="Andreas Pürzel portrait" />
-          <h3>Andreas Pürzel</h3>
-          <p>Strength Mentor (DASGYM)</p>
+          <h3>Andreas "Andi" Pürzel</h3>
+          <p>Athletic Lead</p>
           <p><a href="mailto:andi@thalos.at">andi@thalos.at</a></p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show team nicknames in quotes
- update Misha's email
- call Andreas an "Athletic Lead"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688afee86d088331baca486a840d2976