### PR TITLE
Add Privacy Policy page and remove it from main nav (footer link retained)

### DIFF
--- a/about.html
+++ b/about.html
@@ -47,7 +47,7 @@
   </main>
 
   <footer>
-    &copy; 2025 Thalos. All rights reserved.
+    &copy; 2025 Thalos. All rights reserved. | <a href="privacy.html">Privacy Policy</a>
   </footer>
   <script src="script.js"></script>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -44,7 +44,7 @@
   </main>
 
   <footer>
-    &copy; 2025 Thalos. All rights reserved.
+    &copy; 2025 Thalos. All rights reserved. | <a href="privacy.html">Privacy Policy</a>
   </footer>
   <script src="script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
   </section>
 
   <footer>
-    &copy; 2025 Thalos. All rights reserved.
+    &copy; 2025 Thalos. All rights reserved. | <a href="privacy.html">Privacy Policy</a>
   </footer>
 
   <blockquote class="quote">

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy | Thalos</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav>
+    <a href="index.html" class="logo">THALOS</a>
+    <button class="nav-toggle" id="menu-toggle" aria-label="Toggle navigation">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+    <ul class="nav-menu">
+      <li><a href="index.html">HOME</a></li>
+      <li><a href="about.html">ABOUT</a></li>
+      <li><a href="science.html">SCIENCE</a></li>
+      <li><a href="team.html">TEAM</a></li>
+      <li><a href="contact.html">CONTACT</a></li>
+    </ul>
+  </nav>
+
+  <header class="page-header">
+    <h1>Privacy Policy</h1>
+    <p class="policy-meta">Last updated: 1-1-2026</p>
+  </header>
+
+  <main class="content">
+    <section>
+      <p>This Privacy Policy explains how Thalos AI Fitness Coach GmbH collects, uses, discloses and protects your personal data when you visit our website https://thalos.at and/or use our AI-powered fitness services (together, the “Services”).</p>
+      <p>We take privacy seriously and process your personal data in accordance with the EU General Data Protection Regulation (GDPR) and applicable Austrian data protection laws.</p>
+    </section>
+
+    <section>
+      <h2>1. Who we are (Controller)</h2>
+      <p>Controller: Thalos AI Fitness Coach GmbH<br>
+        Address: Kohlmarkt 4/6, 1010 Vienna, Austria<br>
+        Company registration number: FN 658737 g<br>
+        Email: bob@thalos.at
+      </p>
+      <p>If you have questions about this Privacy Policy or wish to exercise your rights, contact us at the email above.</p>
+    </section>
+
+    <section>
+      <h2>2. What data we collect</h2>
+      <p>Depending on how you use our Services, we may collect the following categories of personal data:</p>
+      <h3>A) Data you provide to us</h3>
+      <ul>
+        <li>Account data (e.g., name, email address, login credentials)</li>
+        <li>Profile information (e.g., age, sex, height, weight, fitness level, preferences)</li>
+        <li>Workout data (e.g., workouts performed, exercises, sets, reps, weights, duration, goals)</li>
+        <li>Nutrition &amp; supplement data (e.g., meal logs, macros/calories, supplements)</li>
+        <li>AI input content (e.g., prompts, goals, answers you give during onboarding or coaching)</li>
+        <li>Customer support messages and requests</li>
+      </ul>
+      <p class="policy-note">(Comparable fitness apps explicitly list workout/fitness/body data as user-provided personal data; Thalos will likely fall into the same category.)</p>
+      <h3>B) Data collected automatically</h3>
+      <ul>
+        <li>Device &amp; usage data (e.g., IP address, browser type, pages viewed, interactions, timestamps)</li>
+        <li>Cookies and similar technologies (e.g., necessary cookies, analytics cookies if enabled)</li>
+      </ul>
+      <p class="policy-note">(MyFitnessPal also lists usage/device data and cookie-based collection as standard.)</p>
+      <h3>C) Data from third parties (optional)</h3>
+      <p>If you connect Thalos to third-party services in the future (e.g., Apple Health, Google Fit, wearables), we may receive related fitness information depending on your permissions. (Only applies if you offer such integrations.)</p>
+    </section>
+
+    <section>
+      <h2>3. Why we use your data (Purposes)</h2>
+      <p>We process personal data for the following purposes:</p>
+      <ul>
+        <li>Provide the Services</li>
+        <li>Create and manage your account</li>
+        <li>Let you log and manage workouts, nutrition, and supplements</li>
+        <li>Store your history and progress</li>
+        <li>AI coaching &amp; personalization</li>
+        <li>Generate personalised workout plans</li>
+        <li>Generate nutrition and supplement recommendations</li>
+        <li>Adapt plans to your goals, fitness level, and training history</li>
+      </ul>
+      <p class="policy-note">(Apps offering AI coaching typically describe personalization as a core processing purpose.)</p>
+      <ul>
+        <li>Improve and secure the Services</li>
+        <li>Debugging, system monitoring, performance improvement</li>
+        <li>Prevent fraud and misuse</li>
+        <li>Communication</li>
+        <li>Respond to customer support requests</li>
+        <li>Send important service messages (e.g., security updates)</li>
+        <li>Legal compliance</li>
+        <li>Accounting and legal obligations</li>
+        <li>Enforcing Terms of Use and protecting rights</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>4. Legal basis for processing (GDPR)</h2>
+      <p>We process your personal data under the following legal bases:</p>
+      <ul>
+        <li>Performance of a contract (Art. 6(1)(b) GDPR): to provide the Services you request</li>
+        <li>Consent (Art. 6(1)(a) GDPR): for optional features (e.g., marketing emails, analytics cookies)</li>
+        <li>Legitimate interests (Art. 6(1)(f) GDPR): service security, fraud prevention, product improvement</li>
+        <li>Legal obligation (Art. 6(1)(c) GDPR): when we must retain data by law</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>5. Health / fitness data</h2>
+      <p>Data such as your workouts, fitness performance, nutrition logs, and body-related metrics may be considered health-related data depending on context.</p>
+      <p>We process such data strictly to provide the Services and personalize your training experience. Where required, we process sensitive data only with your explicit consent (Art. 9 GDPR) or as otherwise permitted by applicable law.</p>
+      <p><strong>Important:</strong> Thalos does not provide medical advice. Always consult a medical professional before starting a training or nutrition program.</p>
+    </section>
+
+    <section>
+      <h2>6. How AI processing works</h2>
+      <p>Thalos uses AI models to generate training, nutrition, and supplement guidance based on the information you provide (e.g., goals, training history, preferences).</p>
+      <p>We may process your inputs to create recommendations and plans.</p>
+      <p>We do not intentionally request sensitive information unrelated to fitness (e.g., political views).</p>
+      <p>You remain responsible for what you input and for applying recommendations safely.</p>
+      <p><strong>AI Training Note (recommended):</strong> Unless explicitly stated otherwise, we do not use your private workout/nutrition content to train public AI models. If this changes, we will clearly disclose it and request consent where required.</p>
+    </section>
+
+    <section>
+      <h2>7. Cookies and tracking</h2>
+      <p>Our website may use cookies and similar technologies.</p>
+      <ul>
+        <li>Necessary cookies: required for site security and basic functionality</li>
+        <li>Analytics cookies (optional): help us understand how users interact with the site (only if enabled and legally permitted)</li>
+      </ul>
+      <p>You can manage cookie preferences in your browser settings.</p>
+      <p class="policy-note">(Use of cookies and tracking for improving services is standard across fitness platforms.)</p>
+    </section>
+
+    <section>
+      <h2>8. Sharing of personal data</h2>
+      <p>We may share personal data only when necessary:</p>
+      <h3>A) Service providers (processors)</h3>
+      <p>We may use trusted third parties (e.g., hosting providers, database services, analytics, email delivery) who process data on our behalf under GDPR-compliant agreements.</p>
+      <h3>B) Legal requirements</h3>
+      <p>We may disclose data if required by law, court order, or to protect rights, safety, and security.</p>
+      <h3>C) Business transfers</h3>
+      <p>If Thalos is involved in a merger, acquisition, or asset sale, your data may be transferred as part of that transaction, subject to legal safeguards.</p>
+      <p>We do not sell your personal data.</p>
+    </section>
+
+    <section>
+      <h2>9. Data retention</h2>
+      <p>We keep personal data only as long as necessary:</p>
+      <ul>
+        <li>while your account is active, and</li>
+        <li>as required for legal, accounting, or security reasons.</li>
+      </ul>
+      <p>You can request deletion of your account at any time.</p>
+    </section>
+
+    <section>
+      <h2>10. International data transfers</h2>
+      <p>If any of our service providers process data outside the European Economic Area (EEA), we ensure appropriate safeguards such as:</p>
+      <ul>
+        <li>EU Commission adequacy decisions, or</li>
+        <li>Standard Contractual Clauses (SCCs)</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>11. Security</h2>
+      <p>We implement technical and organizational measures to protect your data, including access controls, encryption (where appropriate), and secure infrastructure.</p>
+      <p>No system is 100% secure, but we continuously work to protect your information.</p>
+    </section>
+
+    <section>
+      <h2>12. Your rights (GDPR)</h2>
+      <p>You have the right to:</p>
+      <ul>
+        <li>Access your personal data</li>
+        <li>Rectify inaccurate data</li>
+        <li>Delete your data (“right to be forgotten”)</li>
+        <li>Restrict processing</li>
+        <li>Data portability</li>
+        <li>Object to processing (especially based on legitimate interests)</li>
+        <li>Withdraw consent at any time (for consent-based processing)</li>
+      </ul>
+      <p>To exercise your rights, contact: bob@thalos.at</p>
+      <p>You also have the right to lodge a complaint with your supervisory authority, in Austria: Österreichische Datenschutzbehörde (DSB)</p>
+    </section>
+
+    <section>
+      <h2>13. Children’s privacy</h2>
+      <p>Thalos is not intended for children under 16 years. We do not knowingly collect personal data from children.</p>
+    </section>
+
+    <section>
+      <h2>14. Changes to this Privacy Policy</h2>
+      <p>We may update this Privacy Policy from time to time. The updated version will be published on this page and becomes effective when posted.</p>
+    </section>
+  </main>
+
+  <footer>
+    &copy; 2025 Thalos. All rights reserved. | <a href="privacy.html">Privacy Policy</a>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/science.html
+++ b/science.html
@@ -56,7 +56,7 @@
   </main>
 
   <footer>
-    &copy; 2025 Thalos. All rights reserved.
+    &copy; 2025 Thalos. All rights reserved. | <a href="privacy.html">Privacy Policy</a>
   </footer>
   <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -197,6 +197,15 @@ section h2 {
 section p {
   margin-bottom: 1rem;
 }
+.policy-meta {
+  margin: 0.5rem 0 0;
+  color: #bbb;
+  font-style: italic;
+}
+.policy-note {
+  color: #aaa;
+  font-style: italic;
+}
 .technologies ul {
   list-style: disc;
   padding-left: 1.2rem;

--- a/team.html
+++ b/team.html
@@ -66,7 +66,7 @@
   </main>
 
   <footer>
-    &copy; 2025 Thalos. All rights reserved.
+    &copy; 2025 Thalos. All rights reserved. | <a href="privacy.html">Privacy Policy</a>
   </footer>
   <script src="script.js"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Provide a GDPR-focused Privacy Policy page for the site so users can view data practices and rights. 
- Keep the policy discoverable while avoiding cluttering the primary navigation menu. 
- Surface the policy update date and inline contextual notes with consistent styling. 

### Description
- Add a new `privacy.html` page containing the Privacy Policy content and metadata (`Last updated: 1-1-2026`).
- Add `.policy-meta` and `.policy-note` styles to `style.css` to format the policy update date and inline notes.
- Remove the `PRIVACY` link from the global navigation menus in `index.html`, `about.html`, `science.html`, `team.html`, and `contact.html`, while retaining the `Privacy Policy` link in each page footer.
- Update page footers to include a footer link to `privacy.html` so the policy remains accessible site-wide.

### Testing
- Started a local server with `python -m http.server 8000` and confirmed the site served pages successfully. 
- Ran a Playwright script that visited `http://127.0.0.1:8000/privacy.html` and captured `artifacts/privacy-page-no-nav.png` to verify the privacy page renders without a nav link. 
- The Playwright run completed successfully and the screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696510b69978833192f0d9a6a690183f)