### PR TITLE
Add canonical link for homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Thalos – Engineer Performance</title>
+  <link rel="canonical" href="https://thalos.at/" />
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
 </head>


### PR DESCRIPTION
### Motivation
- Google Search Console reported `https://thalos.at/index.html` as "Duplicate without user-selected canonical", so the homepage needs an explicit canonical.
- Make `https://thalos.at/` the user-selected canonical to avoid duplicate indexing of `/` vs `/index.html`.
- Prevent potential SEO/indexing problems by ensuring search engines treat the site root as canonical.

### Description
- Added `<link rel="canonical" href="https://thalos.at/" />` to the `<head>` of `index.html` (placed after the `<title>`).
- The change is a single-line HTML addition and does not modify content, styles, or scripts.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696654bf4bdc8331930ecd8815e8f546)