### PR TITLE
feat(legal): add English versions of all legal pages

### DIFF
--- a/app/[locale]/(legal)/agb/page.tsx
+++ b/app/[locale]/(legal)/agb/page.tsx
@@ -1,5 +1,8 @@
+import { setRequestLocale } from 'next-intl/server';
 import { LegalDocument } from '@/components/ui/LegalDocument';
+import type { Locale } from '@/lib/i18n';
 
-export default function AGB() {
-  return <LegalDocument slug="agb" title="Allgemeine Geschäftsbedingungen" />;
+export default function AGB({ params: { locale } }: { params: { locale: string } }) {
+  setRequestLocale(locale);
+  return <LegalDocument slug="agb" locale={locale as Locale} />;
 }

--- a/app/[locale]/(legal)/datenschutz/page.tsx
+++ b/app/[locale]/(legal)/datenschutz/page.tsx
@@ -1,5 +1,8 @@
+import { setRequestLocale } from 'next-intl/server';
 import { LegalDocument } from '@/components/ui/LegalDocument';
+import type { Locale } from '@/lib/i18n';
 
-export default function Datenschutz() {
-  return <LegalDocument slug="datenschutz" title="Datenschutzerklärung" />;
+export default function Datenschutz({ params: { locale } }: { params: { locale: string } }) {
+  setRequestLocale(locale);
+  return <LegalDocument slug="datenschutz" locale={locale as Locale} />;
 }

--- a/app/[locale]/(legal)/impressum/page.tsx
+++ b/app/[locale]/(legal)/impressum/page.tsx
@@ -1,5 +1,8 @@
+import { setRequestLocale } from 'next-intl/server';
 import { LegalDocument } from '@/components/ui/LegalDocument';
+import type { Locale } from '@/lib/i18n';
 
-export default function Impressum() {
-  return <LegalDocument slug="impressum" title="Impressum" />;
+export default function Impressum({ params: { locale } }: { params: { locale: string } }) {
+  setRequestLocale(locale);
+  return <LegalDocument slug="impressum" locale={locale as Locale} />;
 }

--- a/app/[locale]/(legal)/widerruf/page.tsx
+++ b/app/[locale]/(legal)/widerruf/page.tsx
@@ -1,5 +1,8 @@
+import { setRequestLocale } from 'next-intl/server';
 import { LegalDocument } from '@/components/ui/LegalDocument';
+import type { Locale } from '@/lib/i18n';
 
-export default function Widerruf() {
-  return <LegalDocument slug="widerruf" title="Rücktrittsbelehrung" />;
+export default function Widerruf({ params: { locale } }: { params: { locale: string } }) {
+  setRequestLocale(locale);
+  return <LegalDocument slug="widerruf" locale={locale as Locale} />;
 }

--- a/components/ui/LegalDocument.tsx
+++ b/components/ui/LegalDocument.tsx
@@ -1,13 +1,15 @@
 import 'server-only';
-import { loadLegal, type LegalSlug } from '@/lib/content/legal';
+import { loadLegal, LEGAL_TITLES, type LegalSlug } from '@/lib/content/legal';
+import type { Locale } from '@/lib/i18n';
 
 type Props = {
   slug: LegalSlug;
-  title: string;
+  locale: Locale;
 };
 
-export async function LegalDocument({ slug, title }: Props) {
-  const html = await loadLegal(slug);
+export async function LegalDocument({ slug, locale }: Props) {
+  const html = await loadLegal(slug, locale);
+  const title = LEGAL_TITLES[locale][slug];
   return (
     <main id="main" className="max-w-[800px] mx-auto px-4 md:px-6 py-32">
       <h1 className="text-h1 font-bold tracking-tight text-white">{title}</h1>

--- a/data/legal/agb.en.md
+++ b/data/legal/agb.en.md
@@ -1,0 +1,225 @@
+**THALOS AI FITNESS COACH**
+
+## **General Terms and Conditions**
+
+B2C SaaS membership with app, wearable integration and Polar device
+
+**AGB / GENERAL TERMS**
+
+## 1. Provider, Scope and Contracting Parties
+
+1.1 The provider of the Thalos app and your contractual partner is Thalos Ai Fitness Coach GmbH, Kohlmarkt 4/6, 1010 Vienna, Austria, company register number FN 658737 g, registered with the Commercial Court of Vienna, VAT ID ATU82506012, email: notifications@thalos.at ("Thalos", "we", "us"). Data protection requests should be sent to privacy@thalos.at.
+
+1.2 These General Terms and Conditions ("Terms") apply to consumers within the meaning of Austrian consumer protection law who purchase a digital Thalos membership through the website, app or any other online ordering process. Separate terms may apply to business customers, study participants, B2B partners, gyms, employer programmes and research collaborations.
+
+1.3 Any deviating terms of users shall not apply unless we expressly agree to them in writing.
+
+1.4 These Terms form part of the contract in the version provided before conclusion of the contract. Users may save and print these Terms before placing an order.
+
+1.5 This English version is intended as a clear English-language version of the Terms. If both German and English versions are made available and the order process does not expressly state that English is the binding contract language, the German version shall prevail in case of conflict.
+
+## 2. Definitions
+
+**"App" / "Service"** means the mobile application, web or API components, AI-supported chat and coaching features, training, nutrition, recovery and tracking functions, and related content.
+
+**"Membership"** means the ongoing, periodically billed contractual relationship for use of the Service.
+
+**"Polar Device"** means a Polar wearable or sensor device, including accessories where stated in the order process, provided by Thalos as part of certain memberships.
+
+**"User Data"** means information, content, measurements, photos, videos, logs, comments and other data that users enter, upload or transmit to Thalos through devices or integrations.
+
+**"Performance Data"** means data relating to training, movement, sleep, recovery, nutrition, body metrics, sensor values and similar fitness or wellness aspects. Where such data qualifies as health data under the GDPR, the Privacy Policy and any separate consents shall also apply.
+
+## 3. Purpose of Thalos and Express Exclusion of Medical Services
+
+3.1 Thalos is intended exclusively as a digital fitness, wellness and performance coaching solution for healthy adult users. The Service helps users plan, document and optimise training, nutrition and recovery in everyday life and sport.
+
+3.2 Thalos is not a medical device within the meaning of Regulation (EU) 2017/745, not an in-vitro diagnostic device, not an accessory to a medical device, and not a telemedicine or healthcare service. Thalos is not offered or provided for the diagnosis, prediction, prognosis, prevention, monitoring, treatment or alleviation of diseases, injuries, disabilities or pathological conditions.
+
+3.3 Thalos does not provide medical, physiotherapeutic, psychotherapeutic, medical nutrition, pharmaceutical or other healthcare advice. Use of the Service does not create a doctor-patient, therapist-patient, nutritionist-client or other healthcare treatment relationship.
+
+3.4 Content, chat responses, scores, plans, notices, analyses, warnings and recommendations are provided only for general fitness, wellness, lifestyle and informational purposes. They must not be used for medical decision-making, medication dosing, insulin dosing, supplement dosing, treating symptoms, or interpreting laboratory, glucose, genetic, microbiological or other body-related values.
+
+3.5 In the case of pain, illness, pregnancy, discomfort, abnormal measurements, injury, symptoms, medication use, known pre-existing conditions or uncertainty, users must consult a qualified medical professional before using or continuing training, dieting, fasting, supplementation or any other measure. In emergencies, users must immediately contact the emergency services.
+
+3.6 If any content elsewhere appears unclear or could be misunderstood, this section takes precedence. Marketing texts, app texts and support responses must always be interpreted within this non-medical purpose.
+
+## 4. Eligibility and User Responsibility
+
+4.1 The regular Thalos membership is intended for persons aged 18 or over. Users aged 16 or 17 may use the Service only if Thalos expressly provides a separate minor-specific process and verifiable consent from their legal representatives has been obtained. In such cases, payment, contractual and device-related handling must be carried out by an adult or with the consent of the legal representatives. The regular Thalos App is not intended for persons under 16.
+
+4.2 Users are responsible for deciding whether an exercise, training plan, nutritional change, fasting, supplementation, measuring device or other action is suitable for them. Physical activity may involve significant risks.
+
+4.3 Users must perform all exercises with proper technique, appropriate intensity and due regard for their own ability. In the event of pain, dizziness, shortness of breath, unusual exhaustion, skin irritation from wearables or other warning signs, users must stop using the Service or training and contact an appropriate professional.
+
+4.4 Thalos can generate recommendations only on the basis of the data entered and transmitted. Incomplete, incorrect or delayed information, missing sensor signals, device errors, image or OCR errors, or AI errors may lead to inaccurate recommendations.
+
+## 5. Conclusion of Contract, Order Process and User Account
+
+5.1 The presentation of memberships on the website or in the app does not constitute a binding offer, but an invitation to place an order, unless expressly stated otherwise.
+
+5.2 Before placing an order, users are shown the essential characteristics, prices, taxes, payment terms, term, cancellation options, withdrawal rights, device conditions and these Terms. Input errors can be corrected before completion.
+
+5.3 The contract is concluded when the user confirms the paid order using a clearly labelled button and Thalos accepts the order, for example by activating the account or sending an order confirmation by email.
+
+5.4 The contract language is the language offered in the order process. Unless another binding language is expressly offered, the contract language is German. Users receive, or can download, the order confirmation, Terms, Privacy Policy, withdrawal information and invoice information to the extent required by law.
+
+5.5 Users must keep their login details confidential and must not allow third parties to use their account. Actions carried out through the account will be attributed to the relevant user to the extent permitted by law.
+
+## 6. Membership, Prices, Payment and Cancellation
+
+6.1 The membership runs for an indefinite period and is billed monthly, annually or according to another billing period shown in the order process, depending on the plan selected.
+
+6.2 All prices shown to consumers include VAT and other price components. Any additional costs, such as return shipping costs for a device, will be stated separately before conclusion of the contract where such costs may arise.
+
+6.3 Payment is made using the payment methods offered in the order process. Payment service providers may apply their own terms. Thalos stores full credit card or payment details only where expressly stated; as a rule, such data is processed by the payment service provider.
+
+6.4 The membership may be cancelled at any time. Cancellation takes effect at the end of the current billing period. Refunds for billing periods that have already begun are granted only where required by law or expressly agreed.
+
+6.5 Cancellation must be possible at least through the function provided in the app or customer account and by email to notifications@thalos.at.
+
+6.6 In the event of late payment, Thalos may, after an appropriate reminder and subject to mandatory consumer rights, suspend or terminate access. Outstanding claims remain payable.
+
+## 7. Polar Device: Provision, Return and Pro-Rated Device Value
+
+7.1 If the order process states that a Polar Device is included as part of a membership, the device is provided for use with the Service. The specific device type, scope of delivery, technical requirements and any delivery conditions are set out in the order process.
+
+7.2 The Polar Device is included if the membership is maintained for at least twelve full paid membership months. Until twelve full paid membership months have elapsed, the device is economically provided as part of the ongoing membership. After twelve full paid membership months, the user may keep the device permanently without further payment, unless otherwise agreed in the order process.
+
+7.3 If the membership is cancelled before twelve full paid membership months have elapsed, the Polar Device must be returned within fourteen days after the end of the contract, at the user's own cost, to Thalos Ai Fitness Coach GmbH, Kohlmarkt 4/6, 1010 Vienna, Austria, or to another return address notified by Thalos. Statutory withdrawal rights and mandatory return rules remain unaffected.
+
+7.4 If the device is not returned on time, or if it is not returned in a condition that is undamaged beyond normal wear and tear, Thalos may charge the outstanding pro-rated device value. The maximum device value is EUR 179.90 and decreases pro rata over twelve months with each full paid membership month.
+
+7.5 The calculation formula is: outstanding pro-rated device value = EUR 179.90 × (12 minus number of full paid membership months) / 12. The amount is commercially rounded to two decimal places. After twelve full paid membership months, the outstanding pro-rated device value is EUR 0.00.
+
+7.6 This rule is not a contractual penalty. It is a transparent economic settlement of the device value in the event of early contract termination without timely return of the device. Statutory warranty rights remain unaffected.
+
+7.7 Users must follow the manufacturer's instructions, safety notices and care instructions for the Polar Device. In the event of skin irritation, pain, unusual heat, rash or other discomfort, the device must be removed and medical advice should be sought where appropriate.
+
+## 8. Statutory Right of Withdrawal for Distance Contracts
+
+8.1 Consumers who conclude a contract online generally have a statutory right of withdrawal. Details, deadlines, exceptions, compensation for services already provided and the model withdrawal form are set out in the separate withdrawal information provided before conclusion of the contract.
+
+8.2 If users expressly request that Thalos begins providing the Service before the withdrawal period has expired, a proportionate fee for services already provided may be payable in the event of later withdrawal. For digital content not supplied on a physical medium, the right of withdrawal may expire under the statutory conditions if users expressly consent to immediate performance and confirm that they thereby lose their right of withdrawal.
+
+8.3 The cancellation right under Section 6 and the statutory right of withdrawal are separate rights. Cancellation ends the ongoing membership at the end of the billing period. A valid withdrawal within the statutory period has the legal consequences provided by law.
+
+## 9. Scope of Service, Availability and Changes
+
+9.1 The specific scope of the Service is determined by the selected plan, the order process and the current product description. Thalos may label individual functions as beta, test, preview or experimental features.
+
+9.2 Thalos endeavours to provide high availability, but does not guarantee uninterrupted or error-free availability. Maintenance, updates, security measures, network disruptions, app stores, cloud services, devices, laboratories, payment providers or other third-party providers may impair use.
+
+9.3 Thalos may further develop the Service, implement security updates, and change, replace or remove functions where this is necessary for security, legal compliance, technical development, prevention of misuse, product improvement or economic reasonableness, provided that users are not unreasonably disadvantaged. Material adverse changes will be notified in good time where required by law.
+
+9.4 Users are responsible for compatible devices, internet access, app updates, device connections and the correct use of sensors.
+
+## 10. User Obligations
+
+Users must:
+
+a. keep all information complete, correct and up to date, in particular body data, training status, goals, nutrition, supplements, medication information, pain, discomfort and other relevant circumstances;
+
+b. not upload personal data of third parties, in particular faces, names, licence plates or third-party health data in photos, videos, chat fields or note fields;
+
+c. not take or change illegal, dangerous or medically unverified substances, doping agents, medication doses or insulin doses on the basis of Thalos recommendations;
+
+d. not use the App for medical decisions, emergencies, diagnoses, therapy planning, rehabilitation, disease tracking or injury treatment;
+
+e. respect copyrights, trademarks, data protection rights, personality rights and other third-party rights;
+
+f. not bypass security mechanisms and not carry out automated access, scraping, reverse engineering or any other misuse;
+
+g. use devices, login details and app functions properly and only within the intended purpose.
+
+## 11. AI, Chatbot, Wearable Data and Limits of Results
+
+11.1 Thalos may use AI models, rule-based systems, image and text recognition, speech recognition, LLM-supported functions and statistical models. The outputs are fitness and performance aids, not binding instructions. They may be incomplete, unsuitable or incorrect.
+
+11.2 Users should check and correct important inputs and values, in particular recognised foods, supplements, training data, lactate values, glucose values, laboratory values and other measurement or input values. Section 15 applies to damage resulting from knowingly incorrect, incomplete or unchecked data used contrary to clear notices.
+
+11.3 Sensor and device data may be inaccurate due to poor fit, lack of skin contact, movement artefacts, empty batteries, technical faults, manufacturer limitations, missing calibration or external factors. Thalos does not guarantee any particular accuracy or any particular sporting result.
+
+11.4 Thalos does not replace a personal trainer, medical professional or individual on-site supervision. For demanding exercises, new forms of training or uncertainty, users should seek qualified support on site.
+
+## 12. Data Protection, Data Processing and Use of Anonymised Data
+
+12.1 The processing of personal data is governed by the Privacy Policy and any separately obtained consents. Where Performance Data constitutes special categories of personal data, processing takes place only on a suitable legal basis, in particular explicit consent.
+
+12.2 Users retain their data protection rights. Personal health or fitness data is not sold to advertisers, employers, gyms or other third parties.
+
+12.3 To the extent legally permitted and transparently described in the Privacy Policy or consents, Thalos may process personal data in order to create anonymised or aggregated datasets, benchmarks, insights, models, training data, product improvements and performance insights. Once data has been effectively anonymised and no longer relates to an identifiable person, it may be used, shared, licensed and commercially exploited by Thalos and its affiliated companies for research, product development, AI training, benchmarking, reports, data products and other commercial purposes.
+
+12.4 To the extent necessary for providing, securing, improving and further developing the Service, users grant Thalos a non-exclusive, worldwide, royalty-free, transferable and sublicensable licence to uploaded content. For personal content, this licence applies only within the applicable data protection legal bases. Anonymised or aggregated results, models, benchmarks and derived products may be used permanently.
+
+12.5 In the event of a request for deletion or withdrawal of consent, we will delete personal data or remove the personal reference in accordance with the Privacy Policy and statutory requirements. Effectively anonymised or aggregated data, results, models, benchmarks and products that no longer relate to an identifiable person remain in place and may continue to be used.
+
+## 13. Rights in the App, Content and Trademarks
+
+13.1 All rights in the App, software, trademarks, designs, databases, models, algorithms, texts, graphics, workflows and other elements of the Service remain with Thalos or its licensors.
+
+13.2 For the duration of the membership, users receive a personal, non-exclusive, non-transferable and revocable right to use the App within the contractually intended scope.
+
+13.3 Users may not copy, rent, sell, license, make publicly available, decompile, reverse engineer, modify or use the App or content for a competing product, unless this is mandatorily permitted by law.
+
+## 14. Third-Party Providers, App Stores, Wearables, HealthKit, Laboratories and Payment Services
+
+14.1 The Service may interact with third-party providers, including app stores, payment service providers, cloud providers, communication services, LLM or AI providers, analytics providers, wearable manufacturers, Apple Health/HealthKit, Polar, Dexcom, lactate measuring devices, laboratories or diagnostic partners.
+
+14.2 Third-party services are subject to their own terms, privacy notices, technical limitations and availability. To the extent permitted by law, Thalos is not responsible for the content, measurement accuracy, outages, delays or legal relationships of third-party providers.
+
+14.3 Where Thalos displays or processes data from third-party sources, this does not constitute medical validation or confirmation of the accuracy or completeness of such data.
+
+## 15. Warranty and Liability
+
+15.1 Consumers' statutory warranty rights remain unaffected.
+
+15.2 Thalos has unlimited liability for damage caused by intent or gross negligence and for damage resulting from injury to life, body or health, to the extent attributable to Thalos. Mandatory statutory liability, in particular under product liability law and mandatory consumer law, remains unaffected.
+
+15.3 In cases of slight negligence, Thalos is liable for property damage and financial loss only in the event of a breach of material contractual obligations and only for foreseeable damage typical of the contract. To the extent permitted by law, this liability is limited per damage event to the higher of EUR 100 and the membership fees paid by the affected user in the twelve months preceding the event causing the damage, but in any case to a maximum of EUR 1,000. If the membership has existed for a shorter period, the amount actually paid during that period is decisive.
+
+15.4 To the extent permitted by law, Thalos is not liable for damage caused predominantly by users acting contrary to clear notices, manufacturer instructions, medical advice or these Terms, relying on Thalos for medical decisions, or knowingly providing false or incomplete data.
+
+15.5 Thalos does not owe any particular training, weight, body composition, performance, recovery, sleep, nutrition or other result.
+
+## 16. Suspension, Extraordinary Termination and Misuse
+
+16.1 Thalos may temporarily suspend accounts or terminate the contract for good cause if users materially breach these Terms, misuse the Service, infringe third-party rights, create security risks, fail to make payments despite a reminder, or if legal requirements make this necessary.
+
+16.2 Before suspension or termination, Thalos will, where possible and reasonable, inform the user and give them an opportunity to respond. Immediate action may be necessary in the event of acute security, legal or misuse risks.
+
+## 17. Changes to these Terms
+
+17.1 Thalos may amend these Terms where objective reasons exist, for example changes in law, technical development, new functions, security requirements, changes to the scope of services or clarifications. Changes will be notified in text form.
+
+17.2 To the extent permitted by law, changes are deemed accepted if users do not object within a reasonable period and Thalos separately informs users of this consequence. In the case of material changes to the disadvantage of users, additional statutory requirements apply. Mandatory consumer rights remain unaffected.
+
+## 18. Applicable Law, Consumer Jurisdiction and Final Provisions
+
+18.1 Austrian law applies, excluding the UN Convention on Contracts for the International Sale of Goods. Mandatory consumer protection provisions of the country in which the consumer has their habitual residence remain unaffected.
+
+18.2 The statutory places of jurisdiction apply to consumers. No jurisdiction agreement is made to the disadvantage of consumers.
+
+18.3 If any provision of these Terms is or becomes invalid, the remainder of the contract remains valid. The invalid provision shall be replaced by the applicable statutory provision.
+
+18.4 Contact for contracts, cancellation, withdrawal, devices, complaints and support: notifications@thalos.at. Data protection requests: privacy@thalos.at. Return address: Thalos Ai Fitness Coach GmbH, Kohlmarkt 4/6, 1010 Vienna, Austria, unless another address is notified.
+
+## Annex: Example Calculation of Pro-Rated Device Value
+
+| **Full paid membership months** | **Maximum outstanding pro-rated device value** |
+|---|---|
+| 0 | EUR 179.90 |
+| 1 | EUR 164.91 |
+| 2 | EUR 149.92 |
+| 3 | EUR 134.93 |
+| 4 | EUR 119.93 |
+| 5 | EUR 104.94 |
+| 6 | EUR 89.95 |
+| 7 | EUR 74.96 |
+| 8 | EUR 59.97 |
+| 9 | EUR 44.98 |
+| 10 | EUR 29.98 |
+| 11 | EUR 14.99 |
+| 12 | EUR 0.00 |
+
+This table is provided for transparency. The formula in Section 7.5 and the actual contract and return status are decisive.

--- a/data/legal/datenschutz.en.md
+++ b/data/legal/datenschutz.en.md
@@ -1,0 +1,190 @@
+**THALOS AI FITNESS COACH**
+
+## **Privacy Policy**
+
+App, Website, Wearables, AI Coaching and Performance Data
+
+**DATA PROTECTION / PRIVACY**
+
+## 1. Controller
+
+The controller within the meaning of the General Data Protection Regulation ("GDPR") is Thalos AI Fitness Coach GmbH, Kohlmarkt 4/6, 1010 Vienna, Austria, Commercial Register No. FN 658737 g, Commercial Register Court Commercial Court of Vienna, VAT ID ATU82506012.
+
+For data protection matters, please contact: privacy@thalos.at. For general contact, support, complaints and legally relevant notices, please contact: notifications@thalos.at.
+
+This Privacy Policy applies to the Thalos app, website, ordering processes, customer account, support, device and app integrations, and related consumer services.
+
+## 2. Principles
+
+**Transparency and control.** We provide information about the purposes of processing, legal bases, recipients, retention periods and your rights. Where processing is based on consent, you may withdraw your consent at any time with effect for the future.
+
+**Data minimisation and security.** We process data only to the extent necessary for fitness personalisation, contract performance, security, product improvement and legal obligations. We apply technical and organisational measures and restrict internal access on a need-to-know basis.
+
+**Non-medical purpose.** Thalos processes data exclusively for fitness, wellness, lifestyle, performance, app-related and contractual purposes. Thalos does not provide medical diagnosis, therapy, prevention, disease monitoring or emergency care.
+
+**No sale of personal health data.** We do not sell personal fitness or health data to advertisers, employers, gyms or other third parties.
+
+**Use of anonymised data.** We may use, share, license and commercially exploit anonymised or aggregated data, and models, benchmarks, reports, data products and insights derived from such data, provided that individuals can no longer be identified after reasonable assessment.
+
+## 3. Data We Process
+
+Depending on how you use Thalos, your subscription, your consent choices and the integrations you activate, we may process the following categories of data:
+
+| **Data category** | **Examples** |
+|---|---|
+| Account, identity and contact data | Name, email address, telephone number, login data, language, country, customer number, app/account status, consent history. |
+| Contract, payment and device data | Plan, prices, invoices, payment status, billing period, cancellation, withdrawal, device shipment, returns, outstanding pro-rated device value. |
+| Onboarding and profile data | Sex/gender, date of birth/age, height, weight, dominant hand, training background, typical daily structure, goals, sleep goal, performance level, VO2 max, resting heart rate, maximum heart rate. |
+| Wearables and sensor data | Heart rate, HRV/RR/PPI, PPG quality, movement/accelerometer data, steps, activity, sleep times, sleep phases, sleep score, skin temperature, contact status, device ID, battery status, app and device metadata. |
+| Training data | Training plans, workouts, exercises, sets, repetitions, weights, duration, RPE/RIR, breaks, performance data, training logs, photos/videos, CrossFit board photos, free-text notes. |
+| Nutrition data | Meal photos, text entries, timestamps, recognised foods, portions, calories, macros, nutrients, alcohol content, fasting/skipping information, corrections and acceptance status. |
+| Supplements, medication and notes | Supplement/product names, dosage form, ingredients, dosages, photos, information on over-the-counter or prescription medication, free-text notes about stress, recovery, muscle condition, cycle or daily life. |
+| Glucose, lactate and body metrics | Glucose values from CGM/HealthKit, body weight, lactate measurement images, recognised and confirmed lactate values, body composition, performance tests, where used. |
+| Advanced diagnostics | Blood values, hormone values, microbiome data, genetic data, lactate and performance diagnostics, bioimpedance, spiroergometry or similar values, where you participate in relevant features, studies or add-on services. |
+| Support and communication data | Chat, WhatsApp, email and support messages, screenshots, log files, bug reports, feedback, satisfaction and complaint information. |
+| Technical, security and usage data | IP address, device type, operating system, app version, log data, session data, push token, cookie/tracking IDs, usage events, error and performance data. |
+
+**Free text, photos and videos**  
+Please do not upload data relating to third parties. Photos and videos should not contain faces, names, addresses, licence plates, third-party medical documents or other personal data of other people. In particular, when uploading blackboard, whiteboard or workout photos, third-party names and faces should be removed or made unrecognisable before upload.
+
+## 4. Purposes and Legal Bases
+
+| **Purpose** | **Description** | **Legal basis** |
+|---|---|---|
+| Contract performance | Account, ordering, membership, billing, cancellation, device provision, support and core app functions. | Art. 6(1)(b) GDPR; for health data, additionally Art. 9(2)(a) GDPR where required. |
+| Personalised fitness and wellness recommendations | Analysis of profile, training, nutrition, recovery, wearable and sensor data to create plans, scores, insights and coaching responses. | Explicit consent under Art. 6(1)(a) and Art. 9(2)(a) GDPR. Consent may be withdrawn at any time; core functions may then no longer be available. |
+| Device and integration operation | Connection with Polar, Apple Health/HealthKit, CGM, lactate measurement devices, push services and app stores. | Art. 6(1)(b) GDPR; consent where legally or platform-required; for health data, Art. 9(2)(a) GDPR. |
+| Product improvement and AI training | Error analysis, quality assurance, model improvement, OCR/recognition improvement, development of new fitness and performance features, and training/validation of AI models. | Legitimate interests under Art. 6(1)(f) GDPR for non-sensitive technical data; explicit consent for health/special category data; anonymised data falls outside the GDPR. |
+| Anonymised performance science | Creation of anonymised/aggregated benchmarks, models, datasets, reports and data products; use, licensing and commercial exploitation by Thalos, affiliated companies and partners. | Prior processing of personal special category data based on explicit consent or another suitable legal basis; effectively anonymised data is not personal data. |
+| Security and abuse prevention | Log data, access controls, fraud prevention, protection against unauthorised use, incident response. | Art. 6(1)(f) GDPR; where applicable, Art. 6(1)(c) GDPR for legal obligations. |
+| Legal obligations | Accounting, taxes, warranties, consumer rights, official requests, statutory retention obligations. | Art. 6(1)(c) GDPR; where applicable, Art. 6(1)(f) GDPR for legal defence. |
+| Marketing | Newsletters, offers, product information, satisfaction surveys, campaign measurement. | Consent under Art. 6(1)(a) GDPR where required; otherwise legitimate interests for existing customer marketing where legally permitted. You may object at any time. |
+
+## 5. Special Categories of Personal Data and Consent
+
+Many types of data processed by Thalos may qualify as health data, even though Thalos does not use them for medical purposes. This may include heart rate, HRV, sleep, glucose, weight, training, recovery, medication/supplements, blood values, microbiome data and free-text notes with health-related content.
+
+We process such data for personalised fitness and wellness functions only where an appropriate legal basis exists. In the consumer product, this will usually be your explicit consent under Art. 9(2)(a) GDPR in conjunction with Art. 6(1)(a) or Art. 6(1)(b) GDPR.
+
+You may withdraw consent at any time in the app, in your customer account or by email to privacy@thalos.at. Withdrawal does not affect the lawfulness of processing carried out before the withdrawal. After withdrawal, certain functions may be limited or unavailable if they cannot be provided without the relevant data.
+
+For advanced diagnostics, such as blood values or microbiome analysis, additional specific information and consent terms may apply. These will be provided separately where relevant. Such data is not used by Thalos for medical diagnosis or treatment.
+
+## 6. Anonymised, Aggregated and De-identified Data
+
+We may process data from the app to create anonymised or aggregated datasets, AI models, benchmarks, statistical insights, research reports, product features, data products and performance insights. In doing so, personal identifiers are removed, aggregated or protected through technical and organisational measures so that individual users can no longer reasonably be identified.
+
+Once data has been effectively anonymised, it is no longer personal data within the meaning of the GDPR. Such anonymised or aggregated results may be used, shared, licensed, published, integrated into products or monetised by Thalos, affiliated companies within the Thalos/Trace/BioTrace group and selected research, technology or business partners, without identifying individual users.
+
+We do not sell personal fitness or health data. If a use of data could still allow conclusions to be drawn about you, we treat the data as personal data and rely on an appropriate legal basis and safeguards.
+
+Anonymised results, models, benchmarks, reports, data products and other derived insights that were lawfully created before a withdrawal of consent or deletion request, and that no longer allow identification, may continue to be used permanently.
+
+## 7. Recipients and Processors
+
+We share personal data only where necessary for the purposes described in this Privacy Policy, where a legal basis exists and where appropriate data protection agreements or safeguards are in place. Categories of recipients may include:
+
+hosting, cloud, database, storage, security, monitoring and backup providers;
+
+payment providers, invoicing, tax and accounting service providers;
+
+app stores, push notification providers, email, messaging, support and CRM providers;
+
+AI, LLM, image/OCR, speech, analytics and data processing providers;
+
+wearable, sensor and integration providers such as Polar, Apple Health/HealthKit, CGM or lactate device providers, where you use the relevant integration;
+
+laboratories, diagnostics and study partners, where you expressly use relevant add-on services or studies;
+
+affiliated companies, in particular for technical support, product development, research or anonymised/aggregated performance science;
+
+lawyers, tax advisers, auditors, insurers, authorities or courts, where required.
+
+Gyms, coaches, influencers, employers, insurers or corporate wellness partners receive personal data only if you expressly authorise this or if another clear legal basis exists. Otherwise, only aggregated or anonymised information will be shared with such partners.
+
+## 8. International Data Transfers
+
+We aim to process data within the EU/EEA wherever possible. Where service providers or affiliated companies outside the EU/EEA are involved, transfers take place only in accordance with the GDPR, for example on the basis of an adequacy decision, EU Standard Contractual Clauses, additional safeguards or other legally permitted mechanisms.
+
+Where required, we provide further information about key service providers and transfer mechanisms in this Privacy Policy, in a linked sub-processor list or upon appropriate request.
+
+## 9. Retention Periods
+
+| **Type of data** | **Retention criterion** |
+|---|---|
+| Account and contract data | For the duration of the membership and thereafter for as long as legal claims, warranty, tax or statutory retention periods apply. |
+| Invoice and accounting data | In accordance with statutory retention obligations, generally up to seven years, unless longer obligations or legal claims apply. |
+| Fitness, wellness and health data | As long as the membership exists, consent remains valid and the data is required for functions, history, support or legitimate purposes; thereafter deletion or effective anonymisation, unless retention grounds apply. |
+| Support and communication data | As long as required for handling the request, quality assurance, abuse prevention or legal defence. |
+| Security and technical logs | Usually for a short to medium period, depending on the security purpose; longer storage only in the event of incidents, abuse or legal reasons. |
+| Anonymised/aggregated data | Permanently, since it no longer relates to an identifiable person. We review anonymisation and aggregation standards as appropriate. |
+
+We define and implement retention and deletion periods in line with the actual system architecture, applicable providers and legal retention obligations.
+
+## 10. AI, Profiling and Automated Recommendations
+
+Thalos uses AI and profiling within the meaning of the GDPR to personalise training, nutrition, recovery and performance recommendations. Your data may be evaluated statistically and rule-based, and compared with models, historical progressions and benchmarks.
+
+These recommendations do not have legal effect and are not intended to significantly affect you in a comparable way within the meaning of Art. 22 GDPR. They are not medical, they are not binding, and they may be inaccurate. You can review results, correct inputs, withdraw consent and contact support.
+
+If Thalos introduces functions in the future that could have legal or similarly significant effects, Thalos will provide separate information in advance, assess the appropriate legal basis and implement the required safeguards.
+
+## 11. HealthKit, Wearables and Third-Party Sources
+
+If you connect Apple Health/HealthKit, Polar or other third-party sources, you decide in the relevant settings which data is shared. You can change or withdraw permissions there or in the app at any time.
+
+Data from third-party sources may be incomplete or inaccurate. Thalos does not medically validate such data and is not responsible for manufacturer statements, measurement accuracy or third-party terms.
+
+HealthKit data is not used for advertising and is not sold to advertising networks. It is used to provide the selected functions and, where you separately consent, for product improvement and anonymised performance science.
+
+## 12. Cookies, App Analytics and Marketing
+
+The website and app may use cookies, SDKs, pixels or similar technologies. Technically necessary technologies are used for operation, security, contract performance and login. Analytics, marketing or tracking technologies are used only where an appropriate legal basis exists, in particular consent.
+
+Non-essential cookies and SDKs are not activated before consent has been given. App store privacy notices must be consistent with this Privacy Policy.
+
+## 13. Security
+
+We protect personal data through appropriate technical and organisational measures. Depending on the system, these may include encryption in transit and at rest, role-based access controls, the need-to-know principle, access logging, backups, secure development processes, monitoring, incident response, confidentiality obligations and regular review of service providers.
+
+Despite security measures, no absolute security can be guaranteed. Users should use strong passwords, secure their devices and report suspicious activity to notifications@thalos.at.
+
+## 14. Your Rights
+
+Subject to the requirements of the GDPR, you have in particular the following rights:
+
+right of access;
+
+right to rectification;
+
+right to erasure;
+
+right to restriction of processing;
+
+right to data portability;
+
+right to object to processing based on legitimate interests;
+
+right to withdraw consent;
+
+right to lodge a complaint with a supervisory authority.
+
+In Austria, the competent supervisory authority is: Austrian Data Protection Authority, Barichgasse 40–42, 1030 Vienna, Austria, Email: dsb@dsb.gv.at, Website: www.dsb.gv.at.
+
+If you request deletion and the legal requirements are met, we will delete personal data or remove the personal reference so that identification by Thalos or third parties is no longer possible or would require disproportionate effort. We choose the specific technical implementation in compliance with the GDPR, data security, accountability requirements and statutory retention obligations.
+
+Where data is still required for legal reasons, contract performance, billing, legal defence or security, it may continue to be processed on a restricted basis. There is no right to deletion in relation to effectively anonymised or aggregated data, results, models, benchmarks or products that no longer identify you.
+
+Please send requests to privacy@thalos.at. We may require appropriate identity verification before processing a request.
+
+## 15. Minors
+
+Regular Thalos membership is intended for persons aged 18 or over.
+
+For users aged 16 or 17, Thalos may offer a separate minor-specific process. In such cases, Thalos documents the consent of legal guardians, provides understandable privacy information, ensures clear contract and payment handling through an adult or with the consent of legal guardians, and implements additional safeguards.
+
+The regular app is not intended for persons under the age of 16.
+
+## 16. Changes to This Privacy Policy
+
+We may update this Privacy Policy, for example due to new features, service providers, legal changes or changes in data processing. We will communicate material changes in an appropriate manner. Where new purposes require consent, we will obtain separate consent.

--- a/data/legal/impressum.en.md
+++ b/data/legal/impressum.en.md
@@ -1,0 +1,48 @@
+**THALOS AI FITNESS COACH**
+
+## **Legal Notice / Imprint and Health Disclaimer**
+
+**IMPRINT / DISCLAIMER**
+
+## 1. Legal Notice
+
+**Service provider / company**  
+Thalos Ai Fitness Coach GmbH  
+Kohlmarkt 4/6  
+1010 Vienna  
+Austria  
+Website: https://thalos.at  
+Contact for legal notices, complaints, contract matters, cancellations, withdrawals, device-related enquiries and support: notifications@thalos.at  
+Privacy enquiries: privacy@thalos.at  
+Commercial Register Number: FN 658737 g  
+Commercial Register Court: Commercial Court of Vienna  
+VAT Identification Number: ATU82506012  
+Legal form: Limited liability company under Austrian law — GmbH  
+Managing Director / authorised representative: Robert Bruckner, MBA, MSc  
+Business purpose / line of business: Development, operation and commercialisation of software, artificial intelligence and data analytics solutions in the fields of fitness, health and sport; conducting and evaluating scientific studies; trading in products in the fields of fitness, health and sport.  
+Competent supervisory / trade authority: Municipal Authority of the City of Vienna, Municipal District Office for the 1st and 8th Districts, Wipplingerstraße 8, 1010 Vienna, Austria.  
+Chamber membership: Member of the Austrian Federal Economic Chamber and the Vienna Economic Chamber.  
+Applicable trade regulations: Austrian Trade Regulation Act 1994 — Gewerbeordnung 1994, as amended.  
+Media owner and publisher: Thalos Ai Fitness Coach GmbH  
+Responsible for content: Robert Bruckner, MBA, MSc  
+Basic direction of this website: Information about Thalos, digital fitness, wellness and performance coaching services, app features, memberships and company news.
+
+## 2. Health and Fitness Disclaimer
+
+Thalos is a digital fitness, wellness and performance coaching app. The regular membership is intended for healthy adult users aged 18 and over. Users aged 16 or 17 may only participate through a separate minor-specific onboarding process.
+
+Thalos is not a medical device, an in-vitro diagnostic device, a healthcare provider, a doctor, a therapist or a source of medical advice. Content, scores, plans, chat responses, guidance and recommendations provided by Thalos are for general fitness, wellness, lifestyle and performance purposes only.
+
+Thalos must not be used for medical diagnosis, treatment, medication, insulin or supplement dosing, disease or injury management, rehabilitation, emergencies, or the medical interpretation of body, laboratory, glucose, lactate, genetic or microbiome values.
+
+If you experience pain, symptoms, illness, pregnancy, abnormal values, known medical conditions or uncertainty about whether an activity, nutrition experiment, supplement or other measure is appropriate for you, please seek advice from a qualified medical professional before proceeding.
+
+In an emergency, contact the emergency services immediately.
+
+## 3. Consumer Dispute Resolution
+
+We aim to resolve any concerns directly with our customers. Please contact us at notifications@thalos.at. Thalos is not obliged and is not willing to participate in dispute resolution proceedings before a consumer arbitration board, unless participation is required by law. Mandatory consumer rights remain unaffected.
+
+## 4. Short footer version
+
+**Thalos provides fitness, wellness and performance coaching for healthy users. Regular membership 18+. Not a medical device. No medical advice, diagnosis or treatment. For medical questions, contact a doctor; in emergencies, call the emergency services.**

--- a/data/legal/widerruf.en.md
+++ b/data/legal/widerruf.en.md
@@ -1,0 +1,61 @@
+**THALOS AI FITNESS COACH**
+
+## **Right of Withdrawal**
+
+Consumer withdrawal information for distance contracts, digital memberships and Polar devices
+
+**CONSUMER WITHDRAWAL**
+
+## 1. Your right of withdrawal
+
+If you are a consumer, you have the right to withdraw from this contract within fourteen (14) days without giving any reason.
+
+For a digital membership or service, the withdrawal period generally starts on the day after the contract is concluded. If a Polar device or other goods are delivered to you, the withdrawal period for those goods generally starts on the day after you, or a person named by you who is not the carrier, receive the goods.
+
+## 2. How to exercise your right of withdrawal
+
+To exercise your right of withdrawal, you must inform us by a clear statement that you wish to withdraw from the contract. You may use the model withdrawal form below, but this is not required.
+
+Please send your withdrawal statement to: Thalos AI Fitness Coach GmbH, Kohlmarkt 4/6, 1010 Vienna, Austria. Email: notifications@thalos.at. You may also use the online withdrawal function or withdrawal button provided in the THALOS app or on the THALOS website, where available.
+
+To meet the withdrawal deadline, it is sufficient that you send your withdrawal statement before the withdrawal period has expired.
+
+## 3. Effects of withdrawal
+
+If you validly withdraw from the contract, we will refund all payments we have received from you, including delivery costs where legally required, without undue delay and no later than fourteen (14) days from the day on which we receive your withdrawal statement.
+
+We will use the same payment method for the refund that you used for the original payment, unless expressly agreed otherwise. You will not be charged any fees for the refund.
+
+If a device has been delivered to you, we may withhold the refund until we have received the device back or until you have provided proof that you have returned it, whichever occurs first.
+
+You must return the device without undue delay and in any event no later than fourteen (14) days from the day on which you submit your withdrawal statement. Please return the device to Thalos AI Fitness Coach GmbH, Kohlmarkt 4/6, 1010 Vienna, Austria, or to another return address communicated by us. The deadline is met if you send the device before the 14-day period has expired.
+
+You bear the direct costs of returning the device if we informed you of this before the contract was concluded. You are only responsible for any loss in value of the goods if that loss in value results from handling the goods in a way that was not necessary to inspect their condition, characteristics and functioning. If the Polar device has been activated, paired to an account or used in a way that goes beyond normal inspection and testing, THALOS may deduct or charge a handling/value-reduction fee of EUR 50, to the extent permitted by law.
+
+## 4. Start of services before the end of the withdrawal period
+
+If you expressly request that THALOS begins providing the service during the withdrawal period and you later validly withdraw, you must pay a reasonable proportionate amount for the services already provided up to the time of withdrawal, to the extent permitted by law.
+
+For digital content not supplied on a physical medium, the right of withdrawal may cease under the statutory conditions if you expressly agree that the provision of the digital content begins before the end of the withdrawal period and you acknowledge that, by giving this consent, you lose your right of withdrawal. Where relevant digital content is offered, THALOS will request this consent and acknowledgement separately and clearly during checkout.
+
+## 5. Difference between withdrawal and membership cancellation
+
+The statutory right of withdrawal is different from cancelling an ongoing membership. Your THALOS membership runs for an indefinite period and can be cancelled at any time with effect at the end of the current billing period. The right of withdrawal can only be exercised within the statutory withdrawal period and has the legal consequences described above.
+
+## 6. Model withdrawal form
+
+You may use this form if you wish to withdraw from the contract, but you are not required to use it.
+
+To Thalos AI Fitness Coach GmbH, Kohlmarkt 4/6, 1010 Vienna, Austria, Email: notifications@thalos.at
+
+I hereby withdraw from the contract concluded by me for the THALOS membership / the Polar device.
+
+Ordered on: ____________________________  
+Received on, if a device was delivered: ____________________________  
+Name: ____________________________  
+Address: ____________________________  
+Email address of customer account: ____________________________  
+Order/invoice number: ____________________________
+
+Date: ____________________________  
+Signature, only if submitted on paper: ____________________________

--- a/lib/content/legal.ts
+++ b/lib/content/legal.ts
@@ -2,16 +2,40 @@ import 'server-only';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { marked } from 'marked';
+import { defaultLocale, type Locale } from '@/lib/i18n';
 
 export type LegalSlug = 'impressum' | 'datenschutz' | 'agb' | 'widerruf';
 
 const SLUGS: readonly LegalSlug[] = ['impressum', 'datenschutz', 'agb', 'widerruf'];
 
-export async function loadLegal(slug: LegalSlug, cwd: string = process.cwd()): Promise<string> {
+/** Localized page titles (rendered as the <h1>) per legal document. */
+export const LEGAL_TITLES: Record<Locale, Record<LegalSlug, string>> = {
+  de: {
+    impressum: 'Impressum',
+    datenschutz: 'Datenschutzerklärung',
+    agb: 'Allgemeine Geschäftsbedingungen',
+    widerruf: 'Rücktrittsbelehrung',
+  },
+  en: {
+    impressum: 'Legal Notice',
+    datenschutz: 'Privacy Policy',
+    agb: 'General Terms and Conditions',
+    widerruf: 'Right of Withdrawal',
+  },
+};
+
+export async function loadLegal(
+  slug: LegalSlug,
+  locale: Locale = defaultLocale,
+  cwd: string = process.cwd()
+): Promise<string> {
   if (!SLUGS.includes(slug)) {
     throw new Error(`Unknown legal slug: ${slug}`);
   }
-  const file = path.join(cwd, 'data', 'legal', `${slug}.md`);
+  // German is the default and lives in `${slug}.md`; other locales add a
+  // suffix, e.g. `${slug}.en.md`.
+  const filename = locale === defaultLocale ? `${slug}.md` : `${slug}.${locale}.md`;
+  const file = path.join(cwd, 'data', 'legal', filename);
   const md = await fs.readFile(file, 'utf8');
   const body = md.replace(/^---\n[\s\S]*?\n---\n/, '');
   // marked.parse typing doesn't narrow on async:false; cast is required.

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -67,23 +67,43 @@ collections:
     label: Legal
     files:
       - name: impressum
-        label: Impressum
+        label: Impressum (DE)
         file: data/legal/impressum.md
         fields:
           - { name: body, label: Body, widget: markdown }
+      - name: impressum_en
+        label: Imprint (EN)
+        file: data/legal/impressum.en.md
+        fields:
+          - { name: body, label: Body, widget: markdown }
       - name: datenschutz
-        label: Datenschutz
+        label: Datenschutz (DE)
         file: data/legal/datenschutz.md
         fields:
           - { name: body, label: Body, widget: markdown }
+      - name: datenschutz_en
+        label: Privacy (EN)
+        file: data/legal/datenschutz.en.md
+        fields:
+          - { name: body, label: Body, widget: markdown }
       - name: agb
-        label: AGB
+        label: AGB (DE)
         file: data/legal/agb.md
         fields:
           - { name: body, label: Body, widget: markdown }
+      - name: agb_en
+        label: Terms (EN)
+        file: data/legal/agb.en.md
+        fields:
+          - { name: body, label: Body, widget: markdown }
       - name: widerruf
-        label: Widerruf
+        label: Widerruf (DE)
         file: data/legal/widerruf.md
+        fields:
+          - { name: body, label: Body, widget: markdown }
+      - name: widerruf_en
+        label: Right of withdrawal (EN)
+        file: data/legal/widerruf.en.md
         fields:
           - { name: body, label: Body, widget: markdown }
 

--- a/tests/lib/content/legal.test.ts
+++ b/tests/lib/content/legal.test.ts
@@ -12,7 +12,11 @@ describe('loadLegal', () => {
     await fs.mkdir(path.join(tmpDir, 'data', 'legal'), { recursive: true });
     await fs.writeFile(
       path.join(tmpDir, 'data', 'legal', 'impressum.md'),
-      '## Heading\n\nParagraph with **bold** text.\n'
+      '## Heading\n\nGerman paragraph with **bold** text.\n'
+    );
+    await fs.writeFile(
+      path.join(tmpDir, 'data', 'legal', 'impressum.en.md'),
+      '## Heading\n\nEnglish paragraph with **bold** text.\n'
     );
   });
 
@@ -20,14 +24,25 @@ describe('loadLegal', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('renders markdown to HTML', async () => {
-    const html = await loadLegal('impressum', tmpDir);
+  it('renders German markdown to HTML for locale de', async () => {
+    const html = await loadLegal('impressum', 'de', tmpDir);
     expect(html).toContain('<h2>Heading</h2>');
-    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('German paragraph with <strong>bold</strong>');
+  });
+
+  it('loads the English file for locale en', async () => {
+    const html = await loadLegal('impressum', 'en', tmpDir);
+    expect(html).toContain('English paragraph with <strong>bold</strong>');
+    expect(html).not.toContain('German paragraph');
+  });
+
+  it('defaults to German when locale is omitted', async () => {
+    const html = await loadLegal('impressum', undefined, tmpDir);
+    expect(html).toContain('German paragraph');
   });
 
   it('throws on unknown slug', async () => {
-    await expect(loadLegal('unknown' as any, tmpDir)).rejects.toThrow();
+    await expect(loadLegal('unknown' as any, 'de', tmpDir)).rejects.toThrow();
   });
 
   it('strips YAML frontmatter before rendering', async () => {
@@ -35,7 +50,7 @@ describe('loadLegal', () => {
       path.join(tmpDir, 'data', 'legal', 'datenschutz.md'),
       '---\ntitle: X\n---\n## Body\n\nText.\n'
     );
-    const html = await loadLegal('datenschutz', tmpDir);
+    const html = await loadLegal('datenschutz', 'de', tmpDir);
     expect(html).toContain('<h2>Body</h2>');
     expect(html).not.toContain('title: X');
     expect(html).not.toContain('---');


### PR DESCRIPTION
## What

Adds English versions of all four legal pages and wires them to the `/en` routes.

| Page | DE | EN (new) | EN title |
|---|---|---|---|
| Imprint | `impressum.md` | `impressum.en.md` | Legal Notice |
| Privacy | `datenschutz.md` | `datenschutz.en.md` | Privacy Policy |
| Terms | `agb.md` | `agb.en.md` | General Terms and Conditions |
| Withdrawal | `widerruf.md` | `widerruf.en.md` | Right of Withdrawal |

## Why

The `/en/impressum`, `/en/datenschutz`, `/en/agb` and `/en/widerruf` routes were serving the **German** content: `loadLegal` ignored the locale and the page `<h1>` titles were hardcoded in German. This PR makes the legal pages locale-aware and supplies the English source texts.

## Changes

- **`lib/content/legal.ts`** — `loadLegal` is now locale-aware. German (the default) stays in `<slug>.md`; other locales load `<slug>.<locale>.md` (e.g. `impressum.en.md`). Added `LEGAL_TITLES` for localized `<h1>` titles.
- **`components/ui/LegalDocument.tsx`** + the four **`app/[locale]/(legal)/*/page.tsx`** — pass the request locale and call `setRequestLocale`, matching the home page pattern.
- **`data/legal/*.en.md`** (4 new files) — the supplied English legal texts, formatted to match the German files (headings, address blocks, GFM tables).
- **`public/admin/config.yml`** — all eight legal files (DE + EN) are now editable in Sveltia CMS; DE entries relabeled `(DE)`, new EN entries `(EN)`.
- **`tests/lib/content/legal.test.ts`** — extended (TDD) to cover locale-aware loading.

## Reviewer notes

- **Content edit:** dropped the `Version: [insert date]` placeholder line from the Terms source — template stub, not publishable. Add a real version date if wanted.
- EN URLs keep the German slugs (`/en/impressum`, `/en/agb`, …). Works; English slugs could be a later SEO improvement.
- Footer nav label is "Imprint" while the page `<h1>` is "Legal Notice" (the document's own title) — minor intentional mismatch.

## Verification

- `vitest run` → 41/41 pass
- `tsc --noEmit` → clean
- `next lint` → clean
- `next build` → 18 pages incl. `/de` + `/en` of all four legal routes
- Prerendered HTML confirmed: `/en/*` = English content + English title, `/de/*` still German, tables render