### PR TITLE
feat(science): Wissenschaft/Science subpage + Partner Gym CTA fix

### DIFF
--- a/app/[locale]/science/page.tsx
+++ b/app/[locale]/science/page.tsx
@@ -1,0 +1,408 @@
+import type { Metadata } from 'next';
+import { setRequestLocale } from 'next-intl/server';
+import { useTranslations, useLocale } from 'next-intl';
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Dumbbell,
+  Utensils,
+  Moon,
+  HeartPulse,
+  Layers,
+  Trophy,
+  Gauge,
+  Brain,
+  Compass,
+  Repeat,
+  Activity,
+  Database,
+  LineChart,
+  Clock,
+  UserCheck,
+  Ruler,
+  Sparkles,
+  User,
+  Users,
+  Building2,
+  type LucideIcon,
+} from 'lucide-react';
+import { Icon } from '@/components/ui/Icon';
+import { Button } from '@/components/ui/Button';
+import { Reveal } from '@/components/motion/Reveal';
+import { FAQAccordion } from '@/components/ui/FAQAccordion';
+
+export const metadata: Metadata = {
+  title: 'Thalos Science — Vienna Performance Study',
+  description:
+    'How Thalos turns 26 weeks of high-density human performance data — training, nutrition, recovery and biomarkers — into sharper, individual coaching.',
+};
+
+export default function SciencePage({
+  params: { locale },
+}: {
+  params: { locale: string };
+}) {
+  setRequestLocale(locale);
+  return <ScienceContent />;
+}
+
+function ScienceContent() {
+  const t = useTranslations('sciencePage');
+  const locale = useLocale();
+
+  const home = `/${locale}`;
+  const foundingHref = `/${locale}/founding-athlete`;
+  const contactHref = `${home}#contact`;
+
+  const figures = t('figures.items')
+    .split('|')
+    .map((s) => s.split('::'));
+  const coreCards = splitPairs(t('core.cards'));
+  const layers = splitPairs(t('study.layers'));
+  const steps = t('stack.steps')
+    .split('|')
+    .map((s) => s.split('::'));
+  const roadmap = t('roadmap.items')
+    .split('|')
+    .map((s) => s.split('::'));
+  const principles = splitPairs(t('principles.items'));
+  const faqItems = t('faq.items')
+    .split('|')
+    .map((s) => {
+      const [q, a] = s.split('::');
+      return { q, a };
+    });
+
+  const layerIcons: LucideIcon[] = [Dumbbell, Utensils, Moon, HeartPulse, Layers, Trophy];
+  const stepIcons: LucideIcon[] = [Gauge, Layers, Brain, Compass, Repeat];
+  const roadmapIcons: LucideIcon[] = [Activity, Database, LineChart];
+  const principleIcons: LucideIcon[] = [Clock, UserCheck, Layers, Moon, Ruler, Sparkles];
+
+  return (
+    <main id="main" className="relative overflow-hidden">
+      {/* Ambient background glows */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-[720px] bg-[radial-gradient(ellipse_at_50%_-10%,rgba(0,224,255,0.12),transparent_60%)]"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute left-1/2 top-[1600px] h-[600px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(0,224,255,0.06),transparent_65%)]"
+      />
+
+      <div className="relative max-w-[1120px] mx-auto px-4 md:px-6 pt-24 md:pt-28 pb-24">
+        <Link
+          href={home}
+          className="inline-flex items-center gap-1.5 text-caption text-steel transition-colors hover:text-cyan"
+        >
+          <ArrowLeft size={16} />
+          {t('backHome')}
+        </Link>
+
+        {/* ── Hero ─────────────────────────────────────────────────── */}
+        <div className="mt-10 md:mt-14 grid items-start gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:gap-14">
+          <Reveal>
+            <span className="inline-flex items-center rounded-full border border-cyan/40 bg-cyan/10 px-3 py-1 text-eyebrow uppercase tracking-eyebrow text-cyan">
+              {t('hero.eyebrow')}
+            </span>
+            <h1 className="mt-5 text-display font-bold tracking-tight text-white">{t('hero.title')}</h1>
+            <p className="mt-6 text-body-lg text-steel max-w-[620px]">{t('hero.lead')}</p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Button href="#data-stack" size="lg" variant="secondary">
+                {t('hero.ctaStack')}
+              </Button>
+              <Button href={foundingHref} size="lg">
+                {t('hero.ctaFounding')}
+              </Button>
+            </div>
+          </Reveal>
+
+          {/* Motto card */}
+          <Reveal delay={0.1}>
+            <div className="relative overflow-hidden rounded-card border border-border-active bg-[rgba(0,224,255,0.04)] p-6 shadow-cta-glow md:p-8">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_80%_0%,rgba(0,224,255,0.16),transparent_55%)]"
+              />
+              <div className="relative">
+                <p className="text-h2 font-bold leading-tight tracking-tight text-white">
+                  {t('hero.motto1')}
+                  <br />
+                  {t('hero.motto2')}
+                  <br />
+                  <span className="text-cyan">{t('hero.motto3')}</span>
+                </p>
+                <p className="mt-6 text-body text-steel">{t('hero.uniqueBody')}</p>
+              </div>
+            </div>
+          </Reveal>
+        </div>
+
+        {/* ── Key figures ──────────────────────────────────────────── */}
+        <section className="mt-20 md:mt-24">
+          <Reveal>
+            <SectionEyebrow>{t('figures.eyebrow')}</SectionEyebrow>
+          </Reveal>
+          <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5 md:gap-4">
+            {figures.map(([num, unit, label], i) => (
+              <Reveal key={num + label} delay={i * 0.05} className="h-full">
+                <div className="h-full rounded-card border border-border-default bg-navy p-5">
+                  <div className="flex items-baseline gap-1.5 whitespace-nowrap">
+                    <span className="text-[clamp(24px,2vw,28px)] font-bold leading-none tracking-tight text-cyan tabular-nums">
+                      {num}
+                    </span>
+                    {unit && <span className="text-caption font-semibold uppercase tracking-eyebrow text-cyan/70">{unit}</span>}
+                  </div>
+                  <p className="mt-3 text-caption leading-body text-steel">{label}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Core question ────────────────────────────────────────── */}
+        <section className="mt-24 md:mt-28">
+          <Reveal>
+            <SectionEyebrow>{t('core.eyebrow')}</SectionEyebrow>
+            <h2 className="mt-3 text-h1 font-bold tracking-tight text-white">{t('core.title')}</h2>
+            <p className="mt-4 text-body-lg text-steel max-w-[680px]">{t('core.intro')}</p>
+          </Reveal>
+          <div className="mt-8 grid gap-4 sm:grid-cols-3">
+            {coreCards.map(([label, body], i) => (
+              <Reveal key={label} delay={i * 0.05} className="h-full">
+                <div className="h-full rounded-card border border-border-default bg-navy p-6">
+                  <div className="text-h2 font-semibold text-white">{label}</div>
+                  <p className="mt-2 text-body text-steel">{body}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+          <Reveal>
+            <p className="mt-8 text-h2 font-semibold tracking-tight text-cyan">{t('core.highlight')}</p>
+          </Reveal>
+        </section>
+
+        {/* ── Vienna Performance Study ─────────────────────────────── */}
+        <section className="mt-24 md:mt-28">
+          <Reveal>
+            <SectionEyebrow>{t('study.eyebrow')}</SectionEyebrow>
+            <h2 className="mt-3 text-h1 font-bold tracking-tight text-white">{t('study.title')}</h2>
+            <div className="mt-6 grid gap-4 text-body-lg text-steel md:grid-cols-2 md:gap-10">
+              <p>{t('study.p1')}</p>
+              <p>{t('study.p2')}</p>
+            </div>
+          </Reveal>
+          <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {layers.map(([label, body], i) => (
+              <Reveal key={label} delay={i * 0.05} className="h-full">
+                <div className="h-full rounded-card border border-border-default bg-navy p-6">
+                  <div className="flex items-center gap-3">
+                    <Icon icon={layerIcons[i] ?? Layers} size={22} active />
+                    <span className="text-h2 font-semibold text-white">{label}</span>
+                  </div>
+                  <p className="mt-3 text-body text-steel">{body}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Data stack loop ──────────────────────────────────────── */}
+        <section id="data-stack" className="mt-24 scroll-mt-24 md:mt-28">
+          <Reveal>
+            <SectionEyebrow>{t('stack.eyebrow')}</SectionEyebrow>
+            <h2 className="mt-3 text-h1 font-bold tracking-tight text-white">{t('stack.title')}</h2>
+            <p className="mt-4 text-body-lg text-steel max-w-[680px]">{t('stack.lead')}</p>
+          </Reveal>
+          <ol className="mt-10 space-y-4">
+            {steps.map(([num, title, body], i) => (
+              <Reveal key={num} delay={i * 0.04}>
+                <li className="grid items-start gap-4 rounded-card border border-border-default bg-navy p-6 md:grid-cols-[auto_auto_1fr] md:gap-6">
+                  <span className="select-none text-[40px] font-bold leading-none text-cyan/25 tabular-nums">
+                    {num}
+                  </span>
+                  <span className="hidden md:block">
+                    <Icon icon={stepIcons[i] ?? Repeat} size={26} active />
+                  </span>
+                  <div>
+                    <h3 className="text-h2 font-semibold text-white">{title}</h3>
+                    <p className="mt-2 text-body text-steel">{body}</p>
+                  </div>
+                </li>
+              </Reveal>
+            ))}
+          </ol>
+        </section>
+
+        {/* ── AI roadmap ───────────────────────────────────────────── */}
+        <section className="mt-24 md:mt-28">
+          <Reveal>
+            <SectionEyebrow>{t('roadmap.eyebrow')}</SectionEyebrow>
+            <h2 className="mt-3 text-h1 font-bold tracking-tight text-white">{t('roadmap.title')}</h2>
+            <div className="mt-6 grid gap-4 text-body-lg text-steel md:grid-cols-2 md:gap-10">
+              <p>{t('roadmap.p1')}</p>
+              <p>{t('roadmap.p2')}</p>
+            </div>
+          </Reveal>
+          <div className="mt-10 grid gap-4 md:grid-cols-3">
+            {roadmap.map(([phase, title, body], i) => (
+              <Reveal key={title} delay={i * 0.05} className="h-full">
+                <div className="relative flex h-full flex-col rounded-card border border-border-default bg-navy p-6">
+                  <div className="flex items-center justify-between gap-2">
+                    <Icon icon={roadmapIcons[i] ?? Activity} size={22} active />
+                    <span className="inline-flex items-center rounded-full border border-cyan/40 bg-cyan/10 px-2.5 py-0.5 text-[11px] uppercase tracking-wider text-cyan">
+                      {phase}
+                    </span>
+                  </div>
+                  <h3 className="mt-4 text-h2 font-semibold text-white">{title}</h3>
+                  <p className="mt-2 text-body text-steel">{body}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+          <Reveal>
+            <div className="mt-6 rounded-card border border-border-active bg-[rgba(0,224,255,0.05)] px-6 py-5 text-center shadow-cta-glow">
+              <p className="text-body-lg font-semibold text-white">{t('roadmap.advantage')}</p>
+            </div>
+          </Reveal>
+        </section>
+
+        {/* ── Principles ───────────────────────────────────────────── */}
+        <section className="mt-24 md:mt-28">
+          <Reveal>
+            <SectionEyebrow>{t('principles.eyebrow')}</SectionEyebrow>
+            <h2 className="mt-3 text-h1 font-bold tracking-tight text-white">{t('principles.title')}</h2>
+          </Reveal>
+          <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {principles.map(([title, body], i) => (
+              <Reveal key={title} delay={i * 0.05} className="h-full">
+                <div className="h-full rounded-card border border-border-default bg-navy p-6">
+                  <Icon icon={principleIcons[i] ?? Sparkles} size={22} active />
+                  <h3 className="mt-4 text-h2 font-semibold tracking-tight text-white">{title}</h3>
+                  <p className="mt-2 text-body text-steel">{body}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Audience cards ───────────────────────────────────────── */}
+        <section className="mt-24 md:mt-28">
+          <Reveal>
+            <SectionEyebrow>{t('audience.eyebrow')}</SectionEyebrow>
+            <h2 className="mt-3 text-h1 font-bold tracking-tight text-white">{t('audience.title')}</h2>
+          </Reveal>
+          <div className="mt-10 grid gap-4 md:grid-cols-3">
+            <Reveal className="h-full">
+              <AudienceCard
+                icon={User}
+                title={t('audience.athletesTitle')}
+                body={t('audience.athletesBody')}
+                cta={t('audience.athletesCta')}
+                href={foundingHref}
+              />
+            </Reveal>
+            <Reveal delay={0.05} className="h-full">
+              <AudienceCard
+                icon={Users}
+                title={t('audience.coachesTitle')}
+                body={t('audience.coachesBody')}
+                cta={t('audience.coachesCta')}
+                href={contactHref}
+              />
+            </Reveal>
+            <Reveal delay={0.1} className="h-full">
+              <AudienceCard
+                icon={Building2}
+                title={t('audience.gymsTitle')}
+                body={t('audience.gymsBody')}
+                cta={t('audience.gymsCta')}
+                href={contactHref}
+              />
+            </Reveal>
+          </div>
+        </section>
+
+        {/* ── FAQ ──────────────────────────────────────────────────── */}
+        <section className="mt-24 md:mt-28">
+          <Reveal>
+            <SectionEyebrow>{t('faq.eyebrow')}</SectionEyebrow>
+            <h2 className="mt-3 text-h1 font-bold tracking-tight text-white">{t('faq.title')}</h2>
+          </Reveal>
+          <Reveal>
+            <div className="mt-6">
+              <FAQAccordion items={faqItems} />
+            </div>
+          </Reveal>
+        </section>
+
+        {/* ── Final CTA band ───────────────────────────────────────── */}
+        <Reveal>
+          <section className="relative mt-24 overflow-hidden rounded-card border border-border-active bg-[rgba(0,224,255,0.05)] p-8 text-center shadow-cta-glow md:mt-28 md:p-14">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,rgba(0,224,255,0.18),transparent_60%)]"
+            />
+            <div className="relative">
+              <h2 className="mx-auto max-w-[760px] text-h1 font-bold tracking-tight text-white">
+                {t('finalCta.title')}
+              </h2>
+              <p className="mt-4 text-body-lg font-semibold text-cyan">{t('finalCta.motto')}</p>
+              <div className="mt-8 flex justify-center">
+                <Button href={foundingHref} size="lg">
+                  {t('finalCta.cta')}
+                </Button>
+              </div>
+            </div>
+          </section>
+        </Reveal>
+
+        {/* ── Regulatory ───────────────────────────────────────────── */}
+        <div className="mt-12 border-t border-border-default pt-8">
+          <p className="text-caption text-steel">{t('regulatory')}</p>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function SectionEyebrow({ children }: { children: React.ReactNode }) {
+  return <div className="text-eyebrow uppercase tracking-eyebrow text-cyan">{children}</div>;
+}
+
+function AudienceCard({
+  icon,
+  title,
+  body,
+  cta,
+  href,
+}: {
+  icon: LucideIcon;
+  title: string;
+  body: string;
+  cta: string;
+  href: string;
+}) {
+  return (
+    <div className="flex h-full flex-col rounded-card border border-border-default bg-navy p-6">
+      <Icon icon={icon} size={24} active />
+      <h3 className="mt-4 text-h2 font-semibold text-white">{title}</h3>
+      <p className="mt-2 flex-1 text-body text-steel">{body}</p>
+      <Link
+        href={href}
+        className="mt-5 inline-flex items-center gap-1.5 text-body font-semibold text-cyan transition-colors hover:text-white"
+      >
+        {cta}
+        <ArrowRight size={16} />
+      </Link>
+    </div>
+  );
+}
+
+function splitPairs(raw: string): [string, string][] {
+  return raw.split('|').map((s) => {
+    const [a, b] = s.split('::');
+    return [a, b];
+  });
+}

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -90,6 +90,11 @@ export function Contact() {
 
   return (
     <section id="contact" className="relative py-14 md:py-20 overflow-hidden">
+      {/* Scroll anchors for CTA deep-links (e.g. #contact-partner-gym).
+          Offset above the section so the fixed nav doesn't overlap the heading. */}
+      {Object.keys(HASH_TO_TYPE).map((id) => (
+        <span key={id} id={id} aria-hidden="true" className="pointer-events-none absolute -top-20 left-0" />
+      ))}
       <div
         className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,rgba(0,224,255,0.12),transparent_60%)] pointer-events-none"
         aria-hidden="true"

--- a/components/sections/Science.tsx
+++ b/components/sections/Science.tsx
@@ -16,7 +16,7 @@ export function Science() {
             <h2 className="text-h1 font-bold tracking-tight text-white">{t('title')}</h2>
             <p className="mt-6 text-body-lg text-steel">{t('body')}</p>
             <div className="mt-8">
-              <Button href={`/${locale}#science`} size="md" variant="secondary">{t('cta')}</Button>
+              <Button href={`/${locale}/science`} size="md" variant="secondary">{t('cta')}</Button>
             </div>
             <p className="mt-6 text-caption text-steel">{t('disclaimer')}</p>
           </div>

--- a/lib/content/messages-schema.json
+++ b/lib/content/messages-schema.json
@@ -8,6 +8,7 @@
     "system",
     "productInMotion",
     "science",
+    "sciencePage",
     "youAreUnique",
     "athletes",
     "foundingAthleteBeta",
@@ -100,6 +101,138 @@
         "body": { "type": "string" },
         "cta": { "type": "string" },
         "disclaimer": { "type": "string" }
+      }
+    },
+    "sciencePage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["backHome", "metaTitle", "metaDescription", "hero", "figures", "core", "study", "stack", "roadmap", "principles", "audience", "faq", "finalCta", "regulatory"],
+      "properties": {
+        "backHome": { "type": "string" },
+        "metaTitle": { "type": "string" },
+        "metaDescription": { "type": "string" },
+        "hero": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "lead", "motto1", "motto2", "motto3", "uniqueBody", "ctaStack", "ctaFounding"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "lead": { "type": "string" },
+            "motto1": { "type": "string" },
+            "motto2": { "type": "string" },
+            "motto3": { "type": "string" },
+            "uniqueBody": { "type": "string" },
+            "ctaStack": { "type": "string" },
+            "ctaFounding": { "type": "string" }
+          }
+        },
+        "figures": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "items"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "items": { "type": "string" }
+          }
+        },
+        "core": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "intro", "cards", "highlight"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "intro": { "type": "string" },
+            "cards": { "type": "string" },
+            "highlight": { "type": "string" }
+          }
+        },
+        "study": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "p1", "p2", "layers"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "p1": { "type": "string" },
+            "p2": { "type": "string" },
+            "layers": { "type": "string" }
+          }
+        },
+        "stack": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "lead", "steps"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "lead": { "type": "string" },
+            "steps": { "type": "string" }
+          }
+        },
+        "roadmap": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "p1", "p2", "items", "advantage"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "p1": { "type": "string" },
+            "p2": { "type": "string" },
+            "items": { "type": "string" },
+            "advantage": { "type": "string" }
+          }
+        },
+        "principles": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "items"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "items": { "type": "string" }
+          }
+        },
+        "audience": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "athletesTitle", "athletesBody", "athletesCta", "coachesTitle", "coachesBody", "coachesCta", "gymsTitle", "gymsBody", "gymsCta"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "athletesTitle": { "type": "string" },
+            "athletesBody": { "type": "string" },
+            "athletesCta": { "type": "string" },
+            "coachesTitle": { "type": "string" },
+            "coachesBody": { "type": "string" },
+            "coachesCta": { "type": "string" },
+            "gymsTitle": { "type": "string" },
+            "gymsBody": { "type": "string" },
+            "gymsCta": { "type": "string" }
+          }
+        },
+        "faq": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["eyebrow", "title", "items"],
+          "properties": {
+            "eyebrow": { "type": "string" },
+            "title": { "type": "string" },
+            "items": { "type": "string" }
+          }
+        },
+        "finalCta": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["title", "motto", "cta"],
+          "properties": {
+            "title": { "type": "string" },
+            "motto": { "type": "string" },
+            "cta": { "type": "string" }
+          }
+        },
+        "regulatory": { "type": "string" }
       }
     },
     "youAreUnique": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -47,6 +47,83 @@
     "cta": "Mehr zur Wissenschaft",
     "disclaimer": "Thalos ist eine Performance- und Fitness-Coaching-Plattform. Sie stellt keine medizinischen Diagnosen und keine Therapieempfehlungen bereit."
   },
+  "sciencePage": {
+    "backHome": "Zurück zur Startseite",
+    "metaTitle": "Thalos Science — Vienna Performance Study",
+    "metaDescription": "Wie Thalos aus 26 Wochen dichter Performance-Daten — Training, Nutrition, Recovery und Biomarker — schärferes, individuelles Coaching macht.",
+    "hero": {
+      "eyebrow": "Thalos Science · Vienna Performance Study",
+      "title": "Der Körper ist kein Dashboard. Er ist ein System.",
+      "lead": "Thalos untersucht, wie Training, Nutrition, Recovery und Physiologie über Zeit zusammenwirken — und übersetzt das Signal in schärferes Coaching.",
+      "motto1": "Engineer Performance.",
+      "motto2": "Deep Hack the Human Body.",
+      "motto3": "You Are Unique. Train Unique.",
+      "uniqueBody": "Jeder Athlet reagiert anders. Coaching auf dem nächsten Level beginnt mit dem individuellen Muster: Load, Fuel, Sleep, Stress, Biomarker und Progress in einem verbundenen Loop.",
+      "ctaStack": "Data Stack ansehen",
+      "ctaFounding": "Founding Athlete werden"
+    },
+    "figures": {
+      "eyebrow": "Key Figures",
+      "items": "26::Wochen::Real-World Primary Study|30+::Athletes::Strength- und Hybrid-Kohorte|24h::Signals::Wearables, Recovery und CGM-Layer|31.08.2026::::Studienphase abgeschlossen|Q3/Q4 2026::::Geplanter Forward-Looking Rollout"
+    },
+    "core": {
+      "eyebrow": "Kernfrage",
+      "title": "Was braucht dieser Körper als Nächstes?",
+      "intro": "Die meisten Fitnessprodukte zeigen Zahlen. Thalos verbindet die Zahlen.",
+      "cards": "Training Load::Zählt nur im Kontext.|Nutrition::Zählt nur im Kontext.|Sleep::Zählt nur im Kontext.",
+      "highlight": "Das Signal liegt in der Beziehung dazwischen."
+    },
+    "study": {
+      "eyebrow": "Vienna Performance Study",
+      "title": "High-Density Data. Real Training. Real Athletes.",
+      "p1": "Thalos basiert auf einer Real-World Performance Study mit ausgewählten Strength- und Hybrid-Athletes in Wien. Die Studie begleitet Athletes über Zeit und verbindet Training, Nutrition, Recovery und physiologische Daten in einem longitudinalen Performance Layer.",
+      "p2": "Das Ziel ist nicht mehr Daten um der Daten willen. Das Ziel ist, Beziehungen zu lernen: Welche Signale erklären Progress, Fatigue, Stagnation und Readiness — und wie muss Coaching darauf reagieren?",
+      "layers": "Training::Workout Logs, Load, Volume, Intensity, Exercise History und Performance Tests|Nutrition::Meals, Macros, Supplements, Timing, Consistency und Adherence Patterns|Recovery::Sleep, HRV, Resting Heart Rate, Fatigue und Weekly Questionnaires|Physiology::CGM wo verfügbar, Laktat, Blood Panels, Body Composition und Microbiome Layers|Context::Stress, Illness, Medication, Travel, Menstrual Phase wo relevant und Athlete Notes|Outcome::Strength, Lean Body Mass, Coordination, Cardiovascular Fitness und messbarer Progress"
+    },
+    "stack": {
+      "eyebrow": "Data Stack",
+      "title": "Vom rohen Signal zur Coaching Intelligence.",
+      "lead": "Thalos ist als Loop gebaut. Jede Session, jede Mahlzeit, jede Nacht und jede Messung kann die nächste Empfehlung schärfer machen.",
+      "steps": "01::Measure::Training, Nutrition, Recovery und biometrische Signale mit möglichst wenig Friction erfassen.|02::Contextualize::Bedeutung hinzufügen: Timing, Fatigue, Illness, Supplements, Stress, Sleep und Recent Workload.|03::Model::Baseline lernen und erkennen, wie dieser Körper auf Load, Fuel und Recovery reagiert.|04::Decide::Komplexität in einfache Aktionen übersetzen: was tun, was anpassen, was beobachten.|05::Learn::Das Ergebnis zurück ins Profil führen, damit morgen schärfer startet als heute."
+    },
+    "roadmap": {
+      "eyebrow": "AI Roadmap",
+      "title": "Heute: verstehen. Danach: vorausdenken.",
+      "p1": "Die Beta fokussiert auf Status Analytics. Die forward-looking Algorithmen werden nach Studienende entwickelt, wenn der longitudinale Datensatz vollständig genug für Training und Validierung der nächsten Ebene ist.",
+      "p2": "Jeder Datenpunkt vor dem Forward-Looking Rollout baut das individuelle Performance-Profil. Wenn die Algorithmen live gehen, startet Thalos nicht bei null.",
+      "items": "Live now::Status Analytics::Tägliche Next-Day Training Summaries plus monatliche Workout und Nutrition Analytics. Klare Rückmeldung darüber, was passiert ist.|Nach Studienende::Model Training::Der vollständige Datensatz wird genutzt, um Beziehungen zwischen Behaviour, Biomarkers, Recovery und Performance Outcomes zu lernen.|Ziel: Ende Q3 / Anfang Q4::Forward-Looking Coaching::Adaptive Planung und Prediction: was ändern, bevor Performance fällt, Progress stagniert oder Recovery bricht.",
+      "advantage": "Der Data Advantage startet jetzt."
+    },
+    "principles": {
+      "eyebrow": "Principles",
+      "title": "Sharp Science. Usable Output.",
+      "items": "Longitudinal schlägt Snapshot::Ein Test ist Information. Eine Zeitreihe ist Intelligence.|Individuelle Baseline schlägt Population Average::Der wichtigste Vergleich ist nicht du gegen alle. Es ist du gegen dein eigenes Muster.|Context schlägt isolierte Metrics::Ein Biomarker ohne Training-, Nutrition- und Recovery-Kontext ist ein unvollständiges Signal.|Recovery ist ein Trainingssignal::Sleep, HRV, Soreness und Fatigue sind Teil des Programms — keine Fußnoten.|Modelle müssen messbar sein::Performance Science zählt nur, wenn sie Entscheidungen verändert und Outcomes verbessert.|Science muss nutzbar werden::Der Athlete braucht kein weiteres Spreadsheet. Der Athlete braucht den nächsten richtigen Move."
+    },
+    "audience": {
+      "eyebrow": "Für wen",
+      "title": "Athletes, Coaches und Gyms bekommen dasselbe: Kontext.",
+      "athletesTitle": "For Athletes",
+      "athletesBody": "Verstehe, wie dein Körper reagiert. Baue dein Profil jetzt auf. Train unique.",
+      "athletesCta": "Founding Athlete werden",
+      "coachesTitle": "For Coaches",
+      "coachesBody": "Sieh die Story hinter der Session: Load, Recovery, Nutrition und Progress in einer Sicht.",
+      "coachesCta": "Mit Thalos sprechen",
+      "gymsTitle": "For Partner Gyms",
+      "gymsBody": "Bringe einen science-backed Performance Layer in deine Community und mache Progress messbar.",
+      "gymsCta": "Als Partner Gym bewerben"
+    },
+    "faq": {
+      "eyebrow": "FAQ",
+      "title": "Science without noise.",
+      "items": "Was macht Thalos wissenschaftlich?::Thalos basiert auf longitudinalen Real-World Performance-Daten: Training, Nutrition, Recovery, Wearables und ausgewählte Biomarker-Layer über Zeit verbunden.|Ist Thalos schon forward-looking?::Die Beta fokussiert derzeit auf Status Analytics. Forward-looking Algorithmen sind nach Studienende geplant, sobald der vollständige Datensatz für Model Training verfügbar ist.|Welche Daten nutzt Thalos?::Thalos kann mit Workout Logs, Meals, Notes, Sleep, Heart Rate, HRV, Active Energy, CGM wo verfügbar, Laktat, Bloodwork, Microbiome, Body Composition und Performance Assessments arbeiten.|Sind CGM oder Laktat verpflichtend?::Nein. CGM und Laktat erhöhen die Präzision, aber das System ist darauf ausgelegt, mit den verfügbaren Data Layers jedes Athletes zu arbeiten. In der Studie werden definierte Devices und Protokolle genutzt, um Datenqualität zu maximieren.|Warum Daten sammeln, bevor die Algorithmen live sind?::Weil das individuelle Performance-Profil der Startvorteil ist. Je konsistenter die Datenhistorie, desto schärfer kann Thalos werden, sobald forward-looking Coaching live geht.|Gibt Thalos medizinische Empfehlungen?::Nein. Thalos ist eine Performance- und Fitness-Coaching-Plattform. Thalos bietet keine medizinischen Diagnosen, Therapieempfehlungen oder Emergency Support."
+    },
+    "finalCta": {
+      "title": "Stop guessing. Start modeling.",
+      "motto": "Engineer Performance. Deep Hack the Human Body. You are unique. Train unique.",
+      "cta": "Founding Athlete werden"
+    },
+    "regulatory": "Thalos ist eine Performance- und Fitness-Coaching-Plattform. Thalos ersetzt keine medizinische Diagnose oder Therapieempfehlung."
+  },
   "youAreUnique": {
     "eyebrow": "Auf dich gebaut",
     "title": "Du bist einzigartig. Trainier einzigartig.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -47,6 +47,83 @@
     "cta": "Explore the Science",
     "disclaimer": "Thalos is a performance and fitness coaching platform. It does not provide medical diagnoses or therapy recommendations."
   },
+  "sciencePage": {
+    "backHome": "Back to home",
+    "metaTitle": "Thalos Science — Vienna Performance Study",
+    "metaDescription": "How Thalos turns 26 weeks of high-density human performance data — training, nutrition, recovery and biomarkers — into sharper, individual coaching.",
+    "hero": {
+      "eyebrow": "Thalos Science · Vienna Performance Study",
+      "title": "The body is not a dashboard. It is a system.",
+      "lead": "Thalos studies how training, nutrition, recovery and physiology interact over time — then turns the signal into sharper coaching.",
+      "motto1": "Engineer Performance.",
+      "motto2": "Deep Hack the Human Body.",
+      "motto3": "You Are Unique. Train Unique.",
+      "uniqueBody": "Every athlete responds differently. The only way to coach at the next level is to understand the individual pattern: load, fuel, sleep, stress, biomarkers and progress in one connected loop.",
+      "ctaStack": "Explore the data stack",
+      "ctaFounding": "Become a Founding Athlete"
+    },
+    "figures": {
+      "eyebrow": "Key figures",
+      "items": "26::weeks::Real-world primary study|30+::athletes::Strength and hybrid cohort|24h::signals::Wearables, recovery and CGM layers|31 Aug 2026::::Study phase closes|Q3/Q4 2026::::Forward-looking rollout target"
+    },
+    "core": {
+      "eyebrow": "Core question",
+      "title": "What does this body need next?",
+      "intro": "Most fitness products show numbers. Thalos connects the numbers.",
+      "cards": "Training load::Only matters in context.|Nutrition::Only matters in context.|Sleep::Only matters in context.",
+      "highlight": "The signal is the relationship between them."
+    },
+    "study": {
+      "eyebrow": "Vienna Performance Study",
+      "title": "High-density data. Real training. Real athletes.",
+      "p1": "Thalos is built around a real-world performance study with selected strength and hybrid athletes in Vienna. The study follows athletes over time and combines training, nutrition, recovery and physiological data into one longitudinal performance layer.",
+      "p2": "The goal is not to collect more data for the sake of data. The goal is to learn the relationships: which signals explain progress, fatigue, stagnation and readiness — and how coaching should adapt.",
+      "layers": "Training::Workout logs, load, volume, intensity, exercise history and performance testing|Nutrition::Meals, macros, supplements, timing, consistency and adherence patterns|Recovery::Sleep, HRV, resting heart rate, fatigue and weekly questionnaires|Physiology::CGM where available, lactate, blood panels, body composition and microbiome layers|Context::Stress, illness, medication, travel, menstrual phase where relevant and athlete notes|Outcome::Strength, lean body mass, coordination, cardiovascular fitness and measurable progress"
+    },
+    "stack": {
+      "eyebrow": "Data stack",
+      "title": "From raw signal to coaching intelligence.",
+      "lead": "Thalos is designed as a loop. Every session, meal, night and measurement can make the next recommendation sharper.",
+      "steps": "01::Measure::Collect training, nutrition, recovery and biometric signals with as little friction as possible.|02::Contextualize::Attach meaning: timing, fatigue, illness, supplements, stress, sleep and recent workload.|03::Model::Learn the athlete's baseline and detect how this body responds to load, fuel and recovery.|04::Decide::Translate complexity into simple actions: what to do, what to adjust and what to watch.|05::Learn::Feed the result back into the profile so tomorrow starts sharper than today."
+    },
+    "roadmap": {
+      "eyebrow": "AI roadmap",
+      "title": "Today: understand. Next: predict.",
+      "p1": "The beta focuses on status analytics. The forward-looking algorithms are built after the study closes, when the longitudinal dataset is complete enough to train and validate the next layer.",
+      "p2": "Every data point collected before the forward-looking rollout builds the individual performance profile. When the algorithms go live, Thalos does not start from zero.",
+      "items": "Live now::Status Analytics::Daily next-day training summaries plus monthly workout and nutrition analytics. Clear feedback on what happened.|After study close::Model Training::The completed dataset is used to train models on relationships between behaviour, biomarkers, recovery and performance outcomes.|Target: end Q3 / beginning Q4::Forward-Looking Coaching::Adaptive planning and prediction: what to change before performance drops, progress stalls or recovery breaks down.",
+      "advantage": "The data advantage starts now."
+    },
+    "principles": {
+      "eyebrow": "Principles",
+      "title": "Sharp science. Usable output.",
+      "items": "Longitudinal beats snapshot::One test is information. A time series is intelligence.|Individual baseline beats population average::The most important comparison is not you versus everyone. It is you versus your own pattern.|Context beats isolated metrics::A biomarker without training, nutrition and recovery context is an incomplete signal.|Recovery is a training signal::Sleep, HRV, soreness and fatigue are part of the program — not footnotes.|Models must be measurable::Performance science only matters when it changes decisions and improves outcomes.|Science must become usable::The athlete does not need another spreadsheet. The athlete needs the next right move."
+    },
+    "audience": {
+      "eyebrow": "Who it is for",
+      "title": "Athletes, coaches and gyms get the same thing: context.",
+      "athletesTitle": "For Athletes",
+      "athletesBody": "Understand how your body responds. Build the profile now. Train unique.",
+      "athletesCta": "Become a Founding Athlete",
+      "coachesTitle": "For Coaches",
+      "coachesBody": "See the story behind the session: load, recovery, nutrition and progress in one view.",
+      "coachesCta": "Talk to Thalos",
+      "gymsTitle": "For Partner Gyms",
+      "gymsBody": "Add a science-backed performance layer to your community and make progress measurable.",
+      "gymsCta": "Apply as Partner Gym"
+    },
+    "faq": {
+      "eyebrow": "FAQ",
+      "title": "Science without noise.",
+      "items": "What makes Thalos scientific?::Thalos is built around longitudinal real-world performance data: training, nutrition, recovery, wearables and selected biomarker layers connected over time.|Is Thalos already forward-looking?::The beta currently focuses on status analytics. Forward-looking algorithms are planned after the study closes and the completed dataset is available for model training.|What data does Thalos use?::Thalos can work with workout logs, meals, notes, sleep, heart rate, HRV, active energy, CGM where available, lactate, bloodwork, microbiome, body composition and performance assessments.|Is CGM or lactate required?::No. CGM and lactate add precision, but the system is designed to use the data layers available for each athlete. In the study, specific devices and protocols are used to maximize data quality.|Why collect data before the algorithms are live?::Because the individual performance profile is the starting advantage. The more consistent the data history, the sharper Thalos can become when forward-looking coaching goes live.|Does Thalos give medical advice?::No. Thalos is a performance and fitness coaching platform. It does not provide medical diagnoses, therapy recommendations or emergency support."
+    },
+    "finalCta": {
+      "title": "Stop guessing. Start modeling.",
+      "motto": "Engineer Performance. Deep Hack the Human Body. You are unique. Train unique.",
+      "cta": "Become a Founding Athlete"
+    },
+    "regulatory": "Thalos is a performance and fitness coaching platform. It does not provide medical diagnoses or therapy recommendations."
+  },
   "youAreUnique": {
     "eyebrow": "Built around you",
     "title": "You are unique. Train unique.",


### PR DESCRIPTION
## What

- **New Science subpage** at `/en/science` and `/de/science`, reachable from the homepage Science teaser CTA ("Explore the Science" / "Mehr zur Wissenschaft").
- **Partner Gym CTA fix** — "Als Partner Gym bewerben" now scrolls to the contact form.

## Why

The homepage only had a short Science teaser; the full study/science story needed its own page. Content from the provided review doc (`thalos_science_subpage_review_v1`). The Partner Gym CTA pointed at `#contact-partner-gym`, which had no matching element, so it never scrolled.

## Details

**Science page** (`app/[locale]/science/page.tsx`)
- Styled to match the site + the existing founding-athlete subpage: design tokens, ambient cyan glows, `Reveal` motion, shared `FAQAccordion`.
- Sections: hero + motto card, key figures, core question, Vienna Performance Study data layers, data-stack loop (Measure→Learn), AI roadmap + data-advantage band, principles, audience cards, FAQ, final CTA, regulatory disclaimer.
- Bilingual copy in a new `sciencePage` namespace in `messages/{en,de}.json`, with a matching strict entry in `lib/content/messages-schema.json`. The existing `science` homepage teaser is untouched.
- Homepage Science CTA repointed to `/[locale]/science`.

**Partner Gym CTA** (`components/sections/Contact.tsx`)
- Added real anchor targets for the `#contact-*` deep links. Previously the section relied only on a `hashchange` listener, which doesn't fire on same-page Next `<Link>` navigation. The native anchors also offset below the fixed nav. The inquiry type still preselects (`partner_gym` is the default).

## Verification

- `next build` ✓ — `/de/science` + `/en/science` prerendered (20/20 pages)
- `next lint` ✓ · `vitest` ✓ (39/39) · `validate:messages` ✓ (DE/EN parity)
- Manually verified in browser: both locales render on-brand; Partner Gym CTA scrolls to the contact form with the type preselected.

## Notes for reviewer

- Diff is additive: messages + schema only add the `sciencePage` block; no existing keys reformatted.
- Brand lines (e.g. "Engineer Performance. Deep Hack the Human Body.") are kept in English in both locales, matching the rest of the site.