### PR TITLE
feat(founding-athlete): sold-out state + first-customer registration

### DIFF
--- a/app/[locale]/founding-athlete/page.tsx
+++ b/app/[locale]/founding-athlete/page.tsx
@@ -15,6 +15,7 @@ import {
 import { Icon } from '@/components/ui/Icon';
 import { Button } from '@/components/ui/Button';
 import { Reveal } from '@/components/motion/Reveal';
+import { SoldOutStamp } from '@/components/ui/SoldOutStamp';
 
 export const metadata: Metadata = {
   title: 'Founding Athlete Beta — Thalos',
@@ -34,7 +35,7 @@ export default function FoundingAthletePage({
 function FoundingAthleteContent() {
   const t = useTranslations('foundingAthleteBeta');
   const locale = useLocale();
-  const applyHref = `/${locale}#download`;
+  const applyHref = `/${locale}#contact-first-customer`;
   const passItems = t('pass.items').split('|');
 
   return (
@@ -78,6 +79,11 @@ function FoundingAthleteContent() {
                 aria-hidden="true"
                 className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_80%_0%,rgba(0,224,255,0.16),transparent_55%)]"
               />
+              <SoldOutStamp
+                label={t('soldOutStamp')}
+                note={t('soldOutNote')}
+                className="right-3 top-3 md:right-5 md:top-5"
+              />
               <div className="relative">
                 <span className="inline-flex items-center rounded-full border border-cyan/40 bg-cyan/10 px-3 py-1 text-eyebrow uppercase tracking-eyebrow text-cyan">
                   {t('pass.badge')}
@@ -106,7 +112,7 @@ function FoundingAthleteContent() {
                 </ul>
 
                 <Button href={applyHref} size="lg" className="mt-8 w-full">
-                  {t('ctaBecome')}
+                  {t('ctaFirstCustomer')}
                 </Button>
                 <p className="mt-3 text-center text-caption text-steel">{t('teaserNote')}</p>
               </div>
@@ -155,7 +161,7 @@ function FoundingAthleteContent() {
           </Reveal>
 
           <div className="mt-10 grid gap-4 md:grid-cols-3">
-            <Reveal className="h-full">
+            <Reveal className="relative h-full">
               <PlanCard
                 featured
                 badge={t('plans.foundingBadge')}
@@ -163,6 +169,11 @@ function FoundingAthleteContent() {
                 amount={t('plans.foundingAmount')}
                 suffix={t('plans.foundingSuffix')}
                 feat={t('plans.foundingFeat')}
+              />
+              <SoldOutStamp
+                label={t('soldOutStamp')}
+                note={t('soldOutNote')}
+                className="-right-2 -top-4 md:-right-3 md:-top-5"
               />
             </Reveal>
             <Reveal delay={0.05} className="h-full">
@@ -211,7 +222,7 @@ function FoundingAthleteContent() {
               <p className="mt-4 text-body-lg font-semibold text-cyan">{t('subheadline')}</p>
               <div className="mt-8 flex justify-center">
                 <Button href={applyHref} size="lg">
-                  {t('ctaBecome')}
+                  {t('ctaFirstCustomer')}
                 </Button>
               </div>
               <p className="mt-4 text-caption text-steel">{t('teaserNote')}</p>

--- a/app/api/partner-gym/route.ts
+++ b/app/api/partner-gym/route.ts
@@ -3,6 +3,7 @@ import { Resend } from 'resend';
 import { contactSchema, type InquiryType } from '@/lib/validation';
 
 const SUBJECT_PREFIX: Record<InquiryType, string> = {
+  first_customer: 'First Customer Registration',
   partner_gym: 'Partner Gym Application',
   general: 'General Inquiry',
   founding_athlete: 'Founding Athlete',
@@ -40,7 +41,12 @@ export async function POST(req: Request) {
     lines.push(`Gym: ${data.gym}`);
     lines.push(`City: ${data.city}`);
   }
-  lines.push('', data.message);
+  if (data.inquiryType === 'first_customer') {
+    lines.push(`Country: ${data.country}`);
+    lines.push(`Phone: ${data.phone}`);
+  } else {
+    lines.push('', data.message);
+  }
 
   const resend = new Resend(process.env.RESEND_API_KEY!);
   await resend.emails.send({

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -11,6 +11,7 @@ type FormState = 'idle' | 'submitting' | 'success' | 'error';
 
 // Map URL hash → preselected inquiry type
 const HASH_TO_TYPE: Record<string, InquiryType> = {
+  'contact-first-customer': 'first_customer',
   'contact-partner-gym': 'partner_gym',
   'contact-founding-athlete': 'founding_athlete',
   'contact-press': 'press',
@@ -42,6 +43,7 @@ export function Contact() {
   }, []);
 
   const showGymFields = inquiryType === 'partner_gym';
+  const isFirstCustomer = inquiryType === 'first_customer';
 
   const typeOptions = INQUIRY_TYPES.map((v) => ({
     value: v,
@@ -57,8 +59,13 @@ export function Contact() {
       inquiryType: raw.inquiryType,
       name: raw.name,
       email: raw.email,
-      message: raw.message,
     };
+    if (raw.inquiryType === 'first_customer') {
+      data.country = raw.country;
+      data.phone = raw.phone;
+    } else {
+      data.message = raw.message;
+    }
     if (raw.inquiryType === 'partner_gym') {
       data.gym = raw.gym;
       data.city = raw.city;
@@ -126,9 +133,18 @@ export function Contact() {
             </>
           )}
 
-          <div className="md:col-span-2">
-            <FormTextarea name="message" label={t('form.message')} required error={errors.message} />
-          </div>
+          {isFirstCustomer && (
+            <>
+              <FormInput name="country" label={t('form.country')} required error={errors.country} />
+              <FormInput name="phone" type="tel" label={t('form.phone')} required error={errors.phone} />
+            </>
+          )}
+
+          {!isFirstCustomer && (
+            <div className="md:col-span-2">
+              <FormTextarea name="message" label={t('form.message')} required error={errors.message} />
+            </div>
+          )}
 
           <div className="md:col-span-2 flex flex-col sm:flex-row items-start sm:items-center gap-4">
             <Button size="lg" disabled={state === 'submitting'}>

--- a/components/sections/FoundingAthleteBeta.tsx
+++ b/components/sections/FoundingAthleteBeta.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/Card';
 import { Icon } from '@/components/ui/Icon';
 import { Button } from '@/components/ui/Button';
 import { Reveal } from '@/components/motion/Reveal';
+import { SoldOutStamp } from '@/components/ui/SoldOutStamp';
 
 const CARDS = [
   { key: 'spots', icon: Users },
@@ -23,6 +24,11 @@ export function FoundingAthleteBeta() {
             className="absolute inset-0 bg-[radial-gradient(ellipse_at_15%_0%,rgba(0,224,255,0.14),transparent_55%)] pointer-events-none"
             aria-hidden="true"
           />
+          <SoldOutStamp
+            label={t('soldOutStamp')}
+            note={t('soldOutNote')}
+            className="right-4 top-4 md:right-8 md:top-8"
+          />
           <div className="relative grid lg:grid-cols-2 gap-10 lg:gap-12 p-6 md:p-10 lg:p-14">
             {/* Left: the offer + CTAs */}
             <Reveal>
@@ -35,8 +41,8 @@ export function FoundingAthleteBeta() {
                 <Button href={`/${locale}/founding-athlete`} size="lg">
                   {t('ctaLearnMore')}
                 </Button>
-                <Button href={`/${locale}#download`} size="lg" variant="secondary">
-                  {t('ctaBecome')}
+                <Button href={`/${locale}#contact-first-customer`} size="lg" variant="secondary">
+                  {t('ctaFirstCustomer')}
                 </Button>
               </div>
               <p className="mt-4 text-caption text-steel">{t('teaserNote')}</p>

--- a/components/ui/SoldOutStamp.tsx
+++ b/components/ui/SoldOutStamp.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx';
+
+type Props = {
+  label: string;
+  note: string;
+  className?: string;
+};
+
+/**
+ * Rubber-stamp style "sold out" overlay for the Founding Athlete beta.
+ * Decorative only — pointer-events disabled so it never blocks the card beneath.
+ */
+export function SoldOutStamp({ label, note, className }: Props) {
+  return (
+    <div
+      aria-hidden="true"
+      className={clsx(
+        'pointer-events-none absolute z-20 -rotate-[9deg] select-none',
+        className,
+      )}
+    >
+      <div className="rounded-xl border-2 border-cyan/70 bg-navy/60 px-4 py-2 text-center shadow-cta-glow backdrop-blur-sm md:px-5 md:py-2.5">
+        <div className="text-[15px] font-bold uppercase leading-none tracking-[0.18em] text-cyan md:text-[19px]">
+          {label}
+        </div>
+        <div className="mt-1.5 text-[9px] uppercase leading-none tracking-eyebrow text-steel md:text-[11px]">
+          {note}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/content/messages-schema.json
+++ b/lib/content/messages-schema.json
@@ -303,14 +303,15 @@
         "form": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["inquiryType", "types", "name", "gym", "city", "email", "message", "submit", "success", "error"],
+          "required": ["inquiryType", "types", "name", "gym", "city", "country", "phone", "email", "message", "submit", "success", "error"],
           "properties": {
             "inquiryType": { "type": "string" },
             "types": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["partner_gym", "general", "founding_athlete", "press", "other"],
+              "required": ["first_customer", "partner_gym", "general", "founding_athlete", "press", "other"],
               "properties": {
+                "first_customer": { "type": "string" },
                 "partner_gym": { "type": "string" },
                 "general": { "type": "string" },
                 "founding_athlete": { "type": "string" },
@@ -321,6 +322,8 @@
             "name": { "type": "string" },
             "gym": { "type": "string" },
             "city": { "type": "string" },
+            "country": { "type": "string" },
+            "phone": { "type": "string" },
             "email": { "type": "string" },
             "message": { "type": "string" },
             "submit": { "type": "string" },

--- a/lib/validation.test.ts
+++ b/lib/validation.test.ts
@@ -83,6 +83,39 @@ describe('contactSchema', () => {
     });
   });
 
+  describe('first_customer', () => {
+    it('passes with name/email/country/phone (no message)', () => {
+      const r = contactSchema.safeParse({
+        inquiryType: 'first_customer',
+        name: 'Max',
+        email: 'max@example.com',
+        country: 'Austria',
+        phone: '+43 660 1234567',
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects missing country', () => {
+      const r = contactSchema.safeParse({
+        inquiryType: 'first_customer',
+        name: 'Max',
+        email: 'max@example.com',
+        phone: '+43 660 1234567',
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects missing phone', () => {
+      const r = contactSchema.safeParse({
+        inquiryType: 'first_customer',
+        name: 'Max',
+        email: 'max@example.com',
+        country: 'Austria',
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
   it('rejects unknown inquiryType', () => {
     const r = contactSchema.safeParse({
       inquiryType: 'invalid_type',

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const INQUIRY_TYPES = ['partner_gym', 'general', 'founding_athlete', 'press', 'other'] as const;
+export const INQUIRY_TYPES = ['first_customer', 'partner_gym', 'general', 'founding_athlete', 'press', 'other'] as const;
 export type InquiryType = (typeof INQUIRY_TYPES)[number];
 
 const baseFields = {
@@ -10,6 +10,15 @@ const baseFields = {
 };
 
 export const contactSchema = z.discriminatedUnion('inquiryType', [
+  // Founding Athlete beta is full — early registration for first customers.
+  // Only contact details; no free-text message.
+  z.object({
+    inquiryType: z.literal('first_customer'),
+    name: z.string().min(2).max(120),
+    email: z.string().email(),
+    country: z.string().min(2).max(120),
+    phone: z.string().min(4).max(40),
+  }),
   z.object({
     inquiryType: z.literal('partner_gym'),
     gym: z.string().min(2).max(160),

--- a/messages/de.json
+++ b/messages/de.json
@@ -151,6 +151,9 @@
     "ctaLearnMore": "Beta-Programm ansehen",
     "ctaApply": "Founding Athlete Platz anfragen",
     "ctaBecome": "Founding Athlete werden",
+    "ctaFirstCustomer": "Als Erstkunde registrieren",
+    "soldOutStamp": "Programm voll",
+    "soldOutNote": "Bald folgen mehr",
     "backHome": "Zurück zur Startseite",
     "teaserNote": "100 Plätze · Polar360 Device inklusive · 24 Monate Preisgarantie",
     "pass": {
@@ -255,6 +258,7 @@
     "form": {
       "inquiryType": "Worum geht's?",
       "types": {
+        "first_customer": "Erstkunde werden",
         "partner_gym": "Partner Gym Bewerbung",
         "general": "Allgemeine Anfrage",
         "founding_athlete": "Founding Athlete",
@@ -264,6 +268,8 @@
       "name": "Dein Name",
       "gym": "Studio Name",
       "city": "Stadt",
+      "country": "Land",
+      "phone": "Telefon",
       "email": "E-Mail",
       "message": "Nachricht",
       "submit": "Nachricht senden",

--- a/messages/en.json
+++ b/messages/en.json
@@ -151,6 +151,9 @@
     "ctaLearnMore": "See the beta program",
     "ctaApply": "Apply as Founding Athlete",
     "ctaBecome": "Become a Founding Athlete",
+    "ctaFirstCustomer": "Register to become first customer",
+    "soldOutStamp": "Program full",
+    "soldOutNote": "More to follow soon",
     "backHome": "Back to home",
     "teaserNote": "100 spots · Polar360 device included · 24-month price guarantee",
     "pass": {
@@ -255,6 +258,7 @@
     "form": {
       "inquiryType": "What's this about?",
       "types": {
+        "first_customer": "Become a first customer",
         "partner_gym": "Partner Gym application",
         "general": "General inquiry",
         "founding_athlete": "Founding Athlete",
@@ -264,6 +268,8 @@
       "name": "Your name",
       "gym": "Gym name",
       "city": "City",
+      "country": "Country",
+      "phone": "Phone",
       "email": "Email",
       "message": "Message",
       "submit": "Send Message",

--- a/tests/integration/partner-gym-route.test.ts
+++ b/tests/integration/partner-gym-route.test.ts
@@ -61,6 +61,38 @@ describe('POST /api/partner-gym', () => {
     expect(args.subject).toContain('Max');
   });
 
+  it('200 + sends email for first_customer (country/phone, no message)', async () => {
+    const res = await POST(
+      req({
+        inquiryType: 'first_customer',
+        name: 'Max',
+        email: 'max@example.com',
+        country: 'Austria',
+        phone: '+43 660 1234567',
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const args = sendMock.mock.calls[0][0];
+    expect(args.subject).toContain('First Customer Registration');
+    expect(args.subject).toContain('Max');
+    expect(args.text).toContain('Country: Austria');
+    expect(args.text).toContain('Phone: +43 660 1234567');
+  });
+
+  it('400 if first_customer missing phone', async () => {
+    const res = await POST(
+      req({
+        inquiryType: 'first_customer',
+        name: 'Max',
+        email: 'max@example.com',
+        country: 'Austria',
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
   it('400 if partner_gym missing gym', async () => {
     const res = await POST(
       req({


### PR DESCRIPTION
## What

The 100 Founding Athlete beta spots are filled. Mark the program as **full** and redirect intent toward early **first-customer registration**.

- **Sold-out stamp** — reusable `SoldOutStamp` ("PROGRAM FULL / more to follow soon") overlaid on:
  - homepage Founding Athlete section (over highlight cards)
  - `/founding-athlete` founder-pass card
  - `/founding-athlete` pricing tiers — on the featured *Founding Athlete* plan card
- **CTA swap** — "Become a Founding Athlete" → "Register to become first customer", now pointing at `#contact-first-customer` (was `#download`), on the homepage section, the founder pass, and the final CTA band.
- **First-customer registration** — new `first_customer` inquiry type on the existing contact form: **name / email / country / phone** only (no message). Submissions email `notifications@thalos.at` via the existing Resend route, subject `First Customer Registration — {name}`.

## Files
- `components/ui/SoldOutStamp.tsx` (new)
- `components/sections/FoundingAthleteBeta.tsx`, `app/[locale]/founding-athlete/page.tsx` — stamp + CTA
- `components/sections/Contact.tsx` — hash mapping, conditional country/phone fields, hide message
- `lib/validation.ts`, `app/api/partner-gym/route.ts` — new inquiry type + email body
- `messages/de.json`, `messages/en.json`, `lib/content/messages-schema.json` — strings both locales + schema

## Verification
- `tsc --noEmit` clean · `npm run validate:messages` ✓ · `next build` ✓
- `npm test` — 46 tests pass (+5 new for `first_customer` validation + route)
- Manually verified in browser: stamp renders on all three spots, CTA preselects the `first_customer` form showing name/email/country/phone (no message).

## Reviewer notes
- Reuses the existing `/api/partner-gym` Resend route + `PARTNER_GYM_INBOX` (`notifications@thalos.at`) — no new env vars.
- `.claude/launch.json` (preview dev config) intentionally left untracked.